### PR TITLE
Making use of the new base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,10 @@
-FROM panamax/ruby
+FROM 74.201.240.198:5000/ruby:alpha
 
 ADD . /var/app/panamax-ui
-ADD ctl-base-ui /var/app/ctl-base-ui
+RUN mv /var/app/panamax-ui/ctl-base-ui /var/app/ctl-base-ui
+
+EXPOSE 3000
+
 WORKDIR /var/app/panamax-ui
-RUN bundle install --gemfile=/var/app/panamax-ui/Gemfile
+RUN bundle
 CMD bundle exec rails s

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'jquery-rails'
 gem 'jquery-ui-rails'
 gem 'uglifier', '>= 1.3.0'
 gem 'ctl_base_ui', path: '../ctl-base-ui'
-gem 'faraday'
+gem 'faraday', '0.8.9'
 gem 'activeresource'
 
 group :doc do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,13 +58,15 @@ GEM
       safe_yaml (~> 1.0.0)
     diff-lcs (1.2.5)
     docile (1.1.3)
-    dotenv (0.10.0)
-    dotenv-rails (0.10.0)
-      dotenv (= 0.10.0)
+    dotenv (0.11.1)
+      dotenv-deployment (~> 0.0.2)
+    dotenv-deployment (0.0.2)
+    dotenv-rails (0.11.1)
+      dotenv (= 0.11.1)
     erubis (2.7.0)
     execjs (2.0.2)
-    faraday (0.9.0)
-      multipart-post (>= 1.2, < 3)
+    faraday (0.8.9)
+      multipart-post (~> 1.2.0)
     haml (4.0.5)
       tilt
     hike (1.2.3)
@@ -82,8 +84,8 @@ GEM
     mime-types (1.25.1)
     mini_portile (0.5.3)
     minitest (5.3.3)
-    multi_json (1.9.2)
-    multipart-post (2.0.0)
+    multi_json (1.10.0)
+    multipart-post (1.2.0)
     nokogiri (1.6.1)
       mini_portile (~> 0.5.0)
     phantomjs (1.9.7.0)
@@ -110,7 +112,7 @@ GEM
       activesupport (= 4.1.0)
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
-    rake (10.2.2)
+    rake (10.3.1)
     rdoc (4.1.1)
       json (~> 1.4)
     ref (1.0.5)
@@ -128,8 +130,8 @@ GEM
       rspec-core (~> 2.14.0)
       rspec-expectations (~> 2.14.0)
       rspec-mocks (~> 2.14.0)
-    safe_yaml (1.0.2)
-    sass (3.3.5)
+    safe_yaml (1.0.3)
+    sass (3.3.7)
     sdoc (0.4.0)
       json (~> 1.8)
       rdoc (~> 4.0, < 5.0)
@@ -142,7 +144,7 @@ GEM
       rack (~> 1.4)
       rack-protection (~> 1.4)
       tilt (~> 1.3, >= 1.3.4)
-    sprockets (2.12.0)
+    sprockets (2.12.1)
       hike (~> 1.2)
       multi_json (~> 1.0)
       rack (~> 1.0)
@@ -151,7 +153,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (~> 2.8)
-    teaspoon (0.7.9)
+    teaspoon (0.8.0)
       railties (>= 3.2.5, < 5)
     term-ansicolor (1.3.0)
       tins (~> 1.0)
@@ -185,7 +187,7 @@ DEPENDENCIES
   coveralls
   ctl_base_ui!
   dotenv-rails
-  faraday
+  faraday (= 0.8.9)
   haml
   jquery-rails
   jquery-ui-rails

--- a/config/initializers/teaspoon.rb
+++ b/config/initializers/teaspoon.rb
@@ -42,7 +42,6 @@ Teaspoon.setup do |config|
     # Available frameworks: teaspoon-jasmine, teaspoon-mocha, teaspoon-qunit
     #
     # Note: To use the CoffeeScript source files use `"teaspoon/jasmine"` etc.
-    suite.javascripts = ["teaspoon-jasmine"]
 
     # If you want to change how Teaspoon looks, or include your own stylesheets you can do that here. The default is the
     # stylesheet for the HTML reporter.


### PR DESCRIPTION
Gems are now installed within the base image.  This should speed up start time of panamax-ui containers considerably.
