### PR TITLE
Fixing encoding issue with truncate

### DIFF
--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -35,7 +35,7 @@ class Image < BaseViewModel
   end
 
   def short_description
-    truncate(description, length: 165)
+    truncate(description, length: 165, escape: false, separator: ' ')
   end
 
   def as_json(options={})

--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -14,7 +14,7 @@ class Template < BaseViewModel
   end
 
   def short_description
-    truncate(description, length: 165)
+    truncate(description, length: 165, escape: false, separator: ' ')
   end
 
   def image_count_label


### PR DESCRIPTION
Truncate automatically marks the string html_safe, but has some known escaping issues. 

https://www.pivotaltracker.com/story/show/70193840
