### PR TITLE
Add explicit schemas to ActiveResource models

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,4 +2,9 @@ class Category < BaseResource
 
   self.prefix = '/apps/:app_id/'
 
+  schema do
+    integer :id
+    string :name
+    integer :position
+  end
 end

--- a/app/models/link.rb
+++ b/app/models/link.rb
@@ -1,2 +1,8 @@
 class Link < BaseResource
+
+  schema do
+    integer :service_id
+    string :service_name
+    string :alias
+  end
 end

--- a/app/models/port.rb
+++ b/app/models/port.rb
@@ -1,2 +1,9 @@
 class Port < BaseResource
+
+  schema do
+    string :host_interface
+    integer :host_port
+    integer :container_port
+    string :proto
+  end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -8,6 +8,17 @@ class Service < BaseResource
   has_many :links
   has_one :environment
 
+  schema do
+    integer :id
+    string :name
+    string :description
+    string :from
+    string :load_state
+    string :active_state
+    string :sub_state
+    string :icon
+  end
+
   DEFAULT_ICON_URL = 'http://panamax.ca.tier3.io/service_icons/icon_service_docker_grey.png'
 
   def category_names

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Category do
+
+  it { should respond_to :id }
+  it { should respond_to :name }
+  it { should respond_to :position }
+end

--- a/spec/models/link_spec.rb
+++ b/spec/models/link_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe Link do
+
+  it { should respond_to :service_id }
+  it { should respond_to :service_name }
+  it { should respond_to :alias }
+end

--- a/spec/models/port_spec.rb
+++ b/spec/models/port_spec.rb
@@ -1,0 +1,9 @@
+require 'spec_helper'
+
+describe Port do
+
+  it { should respond_to :host_interface }
+  it { should respond_to :host_port }
+  it { should respond_to :container_port }
+  it { should respond_to :proto }
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -21,9 +21,22 @@ describe Service do
     }
   end
 
+  let(:fake_json_response) { attributes.to_json }
+
   it_behaves_like 'an active resource model'
 
-  let(:fake_json_response) { attributes.to_json }
+  it { should respond_to :id }
+  it { should respond_to :name }
+  it { should respond_to :description }
+  it { should respond_to :from }
+  it { should respond_to :load_state }
+  it { should respond_to :active_state }
+  it { should respond_to :sub_state }
+  it { should respond_to :icon }
+
+  it { should respond_to :ports }
+  it { should respond_to :links }
+  it { should respond_to :environment }
 
   describe '#status' do
     it 'is :running when sub state is running' do


### PR DESCRIPTION
Adding explicit schemas to all of our ActiveResource-based models -- this should resolve a bunch of bugs where the view code assumes there is a particular attribute on a model but it wasn't hydrated on the AR model because it wasn't returned in the API response.

Using an explicit schema means that the AR models are guaranteed to respond to certain methods regardless of the data that was returned in the API response.

[#71687104]
