### PR TITLE
Remove duplicate flash notification.

### DIFF
--- a/app/views/applications/show.html.haml
+++ b/app/views/applications/show.html.haml
@@ -15,8 +15,6 @@
 %header.application
   = render '/shared/breadcrumbs', breadcrumbs: crumbs
 
-= render 'shared/notifications'
-
 %section.deployment-details
   %span.deployment-env
     Deployed to: CoreOS Local

--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -26,9 +26,7 @@
       %span Built by
       %h2 Century Link
     %main
-      - unless flash.empty?
-        - flash.each do |flash_type, notice|
-          %div{ class: "notice-#{flash_type}" }= notice
+      = render 'shared/notifications'
       = yield
     %footer
       .content

--- a/app/views/shared/_notifications.html.haml
+++ b/app/views/shared/_notifications.html.haml
@@ -4,7 +4,7 @@
       %a.dismiss
       %strong
         = flash[key]
-      - if key == 'success' && @app.documentation_to_html.present?
+      - if key == 'success' && @app && @app.documentation_to_html.present?
         %br
         Click
         %a{href:"#", class: "instructions-dialog", "data-doc-url" => documentation_application_url} here


### PR DESCRIPTION
Talked with @grindpattern and @ParkerFleming and we decided that we should display flash notices consistently in the layout, but there was more notification logic in the shared/notifications partial, so I deleted the simple flash loop in the layout and render the partial with more complex logic instead.
[fixes #73391492]
