### PR TITLE
Fix de-serialization issue for service docker status

### DIFF
--- a/app/models/docker_status.rb
+++ b/app/models/docker_status.rb
@@ -1,0 +1,6 @@
+class DockerStatus < Hash
+
+  def initialize(attrs, _=nil)
+    self.merge!(attrs)
+  end
+end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -7,6 +7,7 @@ class Service < BaseResource
   has_many :ports
   has_many :links
   has_one :environment
+  has_one :docker_status
 
   schema do
     integer :id

--- a/spec/models/docker_status_spec.rb
+++ b/spec/models/docker_status_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe DockerStatus do
+
+  describe '#initialize' do
+
+    let(:attrs) { { foo: 'bar', fizz: 'bin' } }
+
+    it 'merges the hash argument into itself' do
+      obj = described_class.new(attrs)
+      expect(obj).to eq attrs
+    end
+  end
+end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -37,6 +37,7 @@ describe Service do
   it { should respond_to :ports }
   it { should respond_to :links }
   it { should respond_to :environment }
+  it { should respond_to :docker_status }
 
   describe '#status' do
     it 'is :running when sub state is running' do


### PR DESCRIPTION
This bug was introduced when the docker status information was added to the `GET /apps/:app_id/services/:service_id` API. The response to that call now includes a bunch of detailed docker-inspect information and some of that data is structured in a way that makes it difficult for ActiveResource to de-serialize it properly.

The fix here is to introduce a new model and instruct ActiveResource to deserialize all of the docker-inspect data into that model (instead of trying to hydrate a graph of different models objects for each item in the response).

[#73818838]
