### PR TITLE
Fixing docker index URL bug

### DIFF
--- a/app/assets/stylesheets/panamax.css.scss
+++ b/app/assets/stylesheets/panamax.css.scss
@@ -259,6 +259,7 @@ h1.breadcrumbs {
   z-index: 1000;
   top: 0;
   left: 0;
+  cursor: not-allowed;
 }
 
 .content-editable {

--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -10,7 +10,8 @@ class ServicesController < ApplicationController
   end
 
   def create
-    service = Service.new(name: params[:name], from: "Image: #{params[:from]}", app_id: params[:app_id])
+    image_with_tag = "#{params[:from]}:#{params[:tag]}"
+    service = Service.new(name: params[:name], from: "Image: #{image_with_tag}", app_id: params[:app_id])
     unless params[:app][:category] == 'null'
       service.categories = [Category.find(params[:app][:category], params: { app_id: params[:app_id] })]
     end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -77,12 +77,16 @@ class Service < BaseResource
     end
   end
 
-  def base_image_name
-    self.from[/(?:(?!:).)*/]
+  def base_image
+    self.from.gsub(/(Image: |Template: )/, '')
   end
 
-  def image_tag_name
-    self.from.gsub(/\S*:/, '')
+  def image_name
+    base_image.split(':').first
+  end
+
+  def image_tag
+    base_image.split(':').last
   end
 
   def category_priority
@@ -90,7 +94,7 @@ class Service < BaseResource
   end
 
   def docker_index_url
-    path_part = "u/#{self.base_image_name}"
+    path_part = "u/#{self.image_name}"
     "#{DOCKER_INDEX_BASE_URL}#{path_part}"
   end
 

--- a/app/views/search/_modal_image_row.html.haml
+++ b/app/views/search/_modal_image_row.html.haml
@@ -16,8 +16,8 @@
       = hidden_field_tag 'app[category]', 'null'
       = hidden_field_tag 'name', presenter.title
       = hidden_field_tag 'from', presenter.title
-      = label 'app[tag]', 'Tag:'
-      = select_tag 'app[tag]',
+      = label 'tag', 'Tag:'
+      = select_tag 'tag',
       options_for_select(['latest']),
       id: nil,
       class: 'image-tag-select',

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -17,10 +17,10 @@
   .base-image-detail
     %h6 Base Image:
     %span
-      = @service.base_image_name
+      = @service.image_name
     %h6 Tag:
     %span
-      = @service.image_tag_name
+      = @service.image_tag
     = link_to 'View on Docker Index', @service.docker_index_url, { target: 'blank' }
 
   = form_for [@app, @service], html: { class: 'service-edit-form' } do |f|

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -66,17 +66,18 @@ describe ServicesController do
 
   describe 'POST #create' do
     let(:dummy_category) { double(:category) }
-    let(:dummy_service) { Service.new(name: 'test', from: 'Image: test') }
+    let(:dummy_service) { Service.new(name: 'test', from: 'Image: test:latest') }
     let(:service_form_params) do
       {
         'app' =>
           {
             'name' => 'Rails',
-            'category' => '1'
+            'category' => '1',
           },
         'name' => 'some image',
         'from' => 'some image',
         'app_id' => '77',
+        'tag' => 'latest',
         'controller' => 'services',
         'action' => 'create',
         'categories' => [{ 'id' => '1' }]
@@ -104,6 +105,7 @@ describe ServicesController do
         from: 'test',
         app_id: '77',
         app: { category: 'null' },
+        tag: 'latest',
         format: :json
       expect(response.status).to eq 200
       expect(response.body).to eql dummy_service.to_json

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -230,17 +230,17 @@ describe Service do
     end
   end
 
-  describe '#base_image_name' do
+  describe '#image_name' do
     it 'returns the base image name without any tag information' do
       subject.from = 'supercool/repository:foobar'
-      expect(subject.base_image_name).to eq 'supercool/repository'
+      expect(subject.image_name).to eq 'supercool/repository'
     end
   end
 
-  describe '#image_tag_name' do
+  describe '#image_tag' do
     it 'returns the tag of the image' do
       subject.from = 'supercool/repository:foobar'
-      expect(subject.image_tag_name).to eq 'foobar'
+      expect(subject.image_tag).to eq 'foobar'
     end
   end
 


### PR DESCRIPTION
We added "Image: " or  "Template: " to the 'from' param, so we need to rework how we display the name, tag, and URL on the details page.

Also added cursor: not-allowed on the yellow indicate new overlay to prevent an overanxious user from getting too click happy before everything finishes.

https://www.pivotaltracker.com/story/show/72471008
