### PR TITLE
cpu spec limit is not reliable for multi core

### DIFF
--- a/app/models/host_health.rb
+++ b/app/models/host_health.rb
@@ -12,19 +12,20 @@ class HostHealth < BaseResource
   def overall
     self.attributes[:stats].last.tap do |results|
       results.attributes[:overall_mem] = overall_memory(self.attributes[:stats], self.attributes[:spec])
-      results.attributes[:overall_cpu] = overall_cpu(self.attributes[:stats], self.attributes[:spec])
+      results.attributes[:overall_cpu] = overall_cpu(self.attributes[:stats])
     end
   end
 
   private
 
-  def overall_cpu(stats, spec)
+  def overall_cpu(stats)
     if stats.count > 1
       sample = stats.pop(2)
       raw = sample[1].attributes[:cpu].attributes[:usage].attributes[:total] -
             sample[0].attributes[:cpu].attributes[:usage].attributes[:total]
+      spec = sample[1].attributes[:cpu].attributes[:usage].attributes[:per_cpu].length
       usage = (raw / 1000000000.0).round(3)
-      percent = (((raw / 1000000.0) / spec.attributes[:cpu].attributes[:limit]) * 100).round(2)
+      percent = ((usage / spec) * 100).round(2)
     end
     {
       'usage' => usage || 0,

--- a/spec/models/host_health_spec.rb
+++ b/spec/models/host_health_spec.rb
@@ -8,7 +8,8 @@ describe HostHealth do
         {
           cpu: {
             usage: {
-              total: 0
+              total: 0,
+              per_cpu: [100]
             }
           },
           memory: {
@@ -18,7 +19,8 @@ describe HostHealth do
         {
           cpu: {
             usage: {
-              total: 10000000
+              total: 10000000,
+              per_cpu: [100]
             }
           },
           memory: {
@@ -40,7 +42,7 @@ describe HostHealth do
   let(:overall) do
     {
       'usage' => 0.01,
-      'percent' => 10.0
+      'percent' => 1.0
     }
   end
 


### PR DESCRIPTION
using the per_cpu array we know the number of cores assigned so we can use the usage metric and divide it by the number of cores \* 100 for percent. The Usage metric is 1.0 \* [number of cpus]
