### PR TITLE
Adding field name to error message

### DIFF
--- a/app/views/shared/_errors.html.haml
+++ b/app/views/shared/_errors.html.haml
@@ -3,4 +3,4 @@
     %strong The following errors prevented you from saving.
     %ul
       - errors.each do |field, message|
-        %li= message
+        %li= "#{field} #{message}"


### PR DESCRIPTION
Adding the field name to the error message
![image](https://cloud.githubusercontent.com/assets/775634/3562503/b5aab178-09f4-11e4-999b-6becda693b4b.png)
