### PR TITLE
Don't submit links that aren't linked to a service.

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -64,7 +64,7 @@ class Service < BaseResource
     self.links = attributes.each_with_object([]) do |(_, link), memo|
       # exclude link ID for now. May need this later if we decide to
       # expose link ID in API.
-      memo << Link.new(link.except('id')) unless link['_deleted'].to_s == '1'
+      memo << Link.new(link.except('id')) unless link['_deleted'].to_s == '1' || link['service_id'].blank?
     end
   end
 

--- a/app/views/services/_service_links.html.haml
+++ b/app/views/services/_service_links.html.haml
@@ -16,6 +16,6 @@
     = add_fields_for(:links, f, { child_index: '_replaceme_' }) do |builder|
       = builder.select :service_id, linkable_service_options(services, service_id), { include_blank: true }, disabled: true, title: 'Name'
       = ':'
-      = builder.text_field :alias, disabled: true, placeholder: 'enter link alias', title: 'Alias'
+      = builder.text_field :alias, disabled: true, placeholder: 'enter link alias', title: 'Alias', id: nil
 
 %button.button-add Add a Linked Service

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -163,13 +163,19 @@ describe Service do
     let(:attributes) do
       {
         '0' => { 'service_id' => 99, 'alias' => 'foo', '_deleted' => false, 'id' => 1 },
-        '1' => { 'service_id' => nil, 'alias' => 'bar', '_deleted' => 1, 'id' => 2 }
+        '1' => { 'service_id' => 78, 'alias' => 'bar', '_deleted' => 1, 'id' => 2 },
+        '2' => { 'service_id' => nil, 'alias' => 'bar', '_deleted' => false, 'id' => 2 }
       }
     end
 
     it 'assigns to links when not deleted' do
       subject.links_attributes = attributes
       expect(subject.links).to eq [Link.new(attributes['0'].except('id'))]
+    end
+
+    it 'does not assign to links when service_id is blank' do
+      subject.links_attributes = attributes
+      expect(subject.links.map(&:alias)).to_not include 'bar'
     end
 
     it 'does not assign to links when _deleted is 1' do


### PR DESCRIPTION
We've been seeing a lot of issues when re-rendering the service management form with errors, especially relating to links. This PR doesn't attempt to send empty links to the API side. It seems to head a lot of headaches off at the pass, however we should still be doing all our API side validations as well.
