### PR TITLE
Handle error when Panamax API is unavaiable

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,17 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  rescue_from EOFError, with: :handle_api_unavailable
+
+  def handle_api_unavailable(ex)
+    logger.error "#{ex.class} - #{ex.message}"
+    logger.error "\t#{ex.backtrace.join("\n\t")}"
+
+    if request.xhr?
+      head :internal_server_error
+    else
+      redirect_to root_path, alert: 'Panamax API is not responding'
+    end
+  end
 end

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -1,0 +1,43 @@
+require 'spec_helper'
+
+describe ApplicationController do
+
+  controller do
+    def index
+      raise EOFError
+    end
+  end
+
+  describe 'handling EOFError' do
+
+    it 'logs some info at the error level' do
+      expect(controller.logger).to receive(:error).twice
+      get :index
+    end
+
+    context 'when request is XHR' do
+
+      before do
+        controller.request.stub(xhr?: true)
+      end
+
+      it 'returns a 500 status code' do
+        get :index
+        expect(response.status).to eq 500
+      end
+    end
+
+    context 'when request is not XHR' do
+
+      it 'redirects to the index' do
+        get :index
+        expect(response).to redirect_to(root_path)
+      end
+
+      it 'flashes an alert' do
+        get :index
+        expect(flash[:alert]).to eq 'Panamax API is not responding'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Set-up a global error handler for the `EOFError` that is raised by ActiveResource whenever the Panamax API is unavailable (this typically happens if the API is simply not running).
