### PR TITLE
Expose ActiveResource error messages

### DIFF
--- a/config/initializers/patches/active_resource_error.rb
+++ b/config/initializers/patches/active_resource_error.rb
@@ -1,0 +1,17 @@
+require 'active_resource/exceptions'
+require 'json'
+
+module ActiveResource
+  class ConnectionError < StandardError
+
+    attr_reader :message
+
+    def initialize(response, message=nil)
+      @response = response
+      @message = JSON.parse(response.try(:body))['message']
+    rescue
+      @message = message
+    end
+
+  end
+end

--- a/spec/config/initializers/patches/active_resource_error_spec.rb
+++ b/spec/config/initializers/patches/active_resource_error_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe ActiveResource::ConnectionError do
+
+  subject { described_class.new(nil) }
+
+  it { should respond_to :message }
+
+  describe '#initialize' do
+
+    context 'when response body is JSON-parseable' do
+      let(:response) do
+        double(:response, body: '{"message":"oops"}')
+      end
+
+      it 'extracts the message attr from the body' do
+        error = described_class.new(response)
+        expect(error.message).to eq 'oops'
+      end
+    end
+
+    context 'when response body is not JSON-parseable' do
+      let(:response) do
+        double(:response, body: 'oops')
+      end
+
+      it 'sets the message attr from the message arg' do
+        error = described_class.new(response, 'foo')
+        expect(error.message).to eq 'foo'
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a monkey-patch to the base ActiveResource error class that will allow us to surface specific error messages when our API returns a 500 status code.

Out of the box, AR exposes error messages that are returned with an HTTP 422 (Unprocessable Entity) response, but any body content returned with a 500 response is swallowed. We use 422 for things like model validation errors, but 500 is more appropriate for things like Fleet/Etcd being unavailable.  Without a specific error message to show the user, the best we can do in the UI is present a generic "something bad happened" message.

This patch will allow us to rescue AR exceptions and then retrieve the specific message that was returned in the response body so we can use it for things like flash messages.

Here's a link to the class that I'm patching:
https://github.com/rails/activeresource/blob/master/lib/active_resource/exceptions.rb#L2-L16

[#75059848]
