### PR TITLE
Fix broken acceptance tests when run in isolation.

### DIFF
--- a/spec/support/fixtures/app_representation.json
+++ b/spec/support/fixtures/app_representation.json
@@ -7,7 +7,8 @@
   "categories": [
     {
       "id": 4,
-      "name": "Web Tier"
+      "name": "Web Tier",
+      "position": 1
     }
   ]
 }


### PR DESCRIPTION
before this commit, if you run `rspec spec/features` it fails. This fix is fairly obvious, but why does it work when ran with the entire suite? Well, if you run `rspec spec/models/category_spec.rb spec/features` it also all passes. Loading the Category class must load the schema, then all subsequent tests that rely on position pass... SPPOOOOKY
