### PR TITLE
Strip carriage returns from template documentation

### DIFF
--- a/app/forms/template_form.rb
+++ b/app/forms/template_form.rb
@@ -19,7 +19,8 @@ class TemplateForm
   end
 
   def documentation
-    @documentation || @app.try(:documentation)
+    doc = @documentation || @app.try(:documentation)
+    doc.gsub(/\r/, '') if doc
   end
 
   def save

--- a/spec/forms/template_form_spec.rb
+++ b/spec/forms/template_form_spec.rb
@@ -64,6 +64,18 @@ describe TemplateForm do
       subject.app = nil
       expect(subject.documentation).to be_nil
     end
+
+    context 'when the documentation contains carriage returns' do
+
+      before do
+        subject.documentation = "line1\r\nline2"
+      end
+
+      it 'strips the carriages returns out' do
+        expect(subject.documentation).to eq "line1\nline2"
+      end
+
+    end
   end
 
   describe '#author' do


### PR DESCRIPTION
In a browser text area, any newline character is encoded as a carriage-return and newline (\r\n) which messes-up the YAML serialization when we go to write the template to a file.

This fix strips out the carriage return characters before sending the data to the API.

[#75441666]
