### PR TITLE
Removing duplicate icon styles

### DIFF
--- a/app/assets/stylesheets/panamax.css.scss
+++ b/app/assets/stylesheets/panamax.css.scss
@@ -275,6 +275,12 @@ h1.breadcrumbs {
     &:hover:after {
       @include icon-red;
     }
+
+    &.disabled {
+      &:hover:after {
+        @include icon-light-grey;
+      }
+    }
   }
 }
 

--- a/app/assets/stylesheets/panamax/manage.css.scss
+++ b/app/assets/stylesheets/panamax/manage.css.scss
@@ -166,56 +166,9 @@
     width: 40px;
     height: 40px;
 
-    a.edit-action {
-      float: left;
-      display: block;
-      width: 20px;
-      height: 20px;
-
-      &:after {
-        content: '';
-        position: absolute;
-        left: 6px;
-        top: 6px;
-        display: block;
-        @include icon-light-grey;
-        @extend .icon-pencil;
-        width: 20px;
-        height: 20px;
-      }
-
-      &:hover:after {
-        @include icon-grey;
-        @extend .icon-pencil;
-      }
-    }
-
+    a.edit-action,
     a.delete-action {
       float: left;
-      display: block;
-      width: 20px;
-      height: 20px;
-
-      &:after {
-        content: '';
-        position: absolute;
-        left: 6px;
-        top: 7px;
-        display: block;
-        @include icon-light-grey;
-        @extend .icon-x;
-        width: 20px;
-        height: 20px;
-      }
-
-      &:hover:after {
-        @include icon-red;
-      }
-    }
-    a.delete-action.disabled {
-      &:hover:after {
-        @include icon-light-grey;
-      }
     }
   }
 
@@ -414,8 +367,6 @@ h1 .actions {
     height: 40px;
 
     &:after {
-      content: '';
-      position: absolute;
       left: 0px;
       top: 0px;
       display: inline-block;
@@ -740,65 +691,13 @@ section.application-services {
           min-height: 50px;
         }
 
-        header .actions {
+        > header .actions {
           position: absolute;
           right:0;
-          top: 0;
+          top: -5px;
           display: none;
           width: 40px;
           height: 40px;
-
-          a.edit-action {
-            float: left;
-            display: block;
-            width: 20px;
-            height: 20px;
-
-            &:after {
-              content: '';
-              position: absolute;
-              left: 6px;
-              top: 6px;
-              display: block;
-              @include icon-light-grey;
-              @extend .icon-pencil;
-              width: 20px;
-              height: 20px;
-            }
-
-            &:hover:after {
-              @include icon-grey;
-              @extend .icon-pencil;
-            }
-          }
-
-          a.delete-action {
-            float: left;
-            display: block;
-            width: 20px;
-            height: 20px;
-
-            &:after {
-              content: '';
-              position: absolute;
-              left: 6px;
-              top: 7px;
-              display: block;
-              @include icon-light-grey;
-              @extend .icon-x;
-              width: 20px;
-              height: 20px;
-            }
-
-            &:hover:after {
-              @include icon-red;
-            }
-          }
-          a.delete-action.disabled {
-            &:hover:after {
-              @include icon-light-grey;
-            }
-          }
         }
 
 


### PR DESCRIPTION
DRYing up the CSS.

All icons (view, edit, inspect) are declared in panamax.css. Use them by adding .edit-action, .view-action, and .delete action to the 'a' tag and the icons will be displayed :after the element.

https://www.pivotaltracker.com/n/projects/1016898/stories/75511656
