### PR TITLE
Allowing templates to have many images

### DIFF
--- a/app/models/template.rb
+++ b/app/models/template.rb
@@ -3,6 +3,8 @@ class Template < BaseResource
   include ApplicationHelper
   include MarkdownRenderable
 
+  has_many :images
+
   schema do
     integer :id
     string :description

--- a/spec/models/template_spec.rb
+++ b/spec/models/template_spec.rb
@@ -62,6 +62,10 @@ describe Template do
     it { should respond_to :documentation }
   end
 
+  describe '#images' do
+    it { should respond_to :images }
+  end
+
   describe '#short_description' do
     subject do
       long_description_attributes = attributes.merge(


### PR DESCRIPTION
templates.images needs to access the image model

https://www.pivotaltracker.com/story/show/75982592
