### PR TITLE
Don't reference the params explicitly in the view.

### DIFF
--- a/app/views/templates/_form.html.haml
+++ b/app/views/templates/_form.html.haml
@@ -41,4 +41,4 @@
     = f.text_area :documentation
 
   = button_tag 'Publish Your Template', class: 'button-positive'
-  = button_tag 'Preview Template File', type: 'button', class: 'button-secondary preview', data: { previewPath: template_app_path(params[:app_id]) }
+  = button_tag 'Preview Template File', type: 'button', class: 'button-secondary preview', data: { previewPath: template_app_path(template_form.app_id) }


### PR DESCRIPTION
This value was nil on re-render and blew up the page.
[#76126088]
