### PR TITLE
Render local image tags as part of search results

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,6 +14,7 @@
 //= require jquery_ujs
 //= require handlebars
 //= require google-code-prettify/prettify
+//= require_tree ./template_helpers
 //= require chosen.jquery
 //= require moment
 //= require pmx_namespace

--- a/app/assets/javascripts/template_helpers/options_for_select.js
+++ b/app/assets/javascripts/template_helpers/options_for_select.js
@@ -1,0 +1,9 @@
+Handlebars.registerHelper('optionsForSelect', function(options) {
+  var optionString = "";
+
+  for(var i=0, j=options.length; i<j; i++) {
+    optionString += '<option value="' + options[i] + '">' + options[i] + '</option>';
+  }
+
+  return optionString;
+});

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -1,6 +1,8 @@
 class ImagePresenter
-  def initialize(image)
+
+  def initialize(image, view_context)
     @image = image
+    @view_context = view_context
   end
 
   delegate :description, :status_label, :badge_class, :short_description,
@@ -11,4 +13,7 @@ class ImagePresenter
     @image.source
   end
 
+  def tag_options
+    @view_context.options_for_select(@image.tags)
+  end
 end

--- a/app/presenters/json_image_presenter.rb
+++ b/app/presenters/json_image_presenter.rb
@@ -26,4 +26,8 @@ class JsonImagePresenter
   def badge_class
     '{{badge_class}}'
   end
+
+  def tag_options
+    '{{{optionsForSelect tags}}}'
+  end
 end

--- a/app/views/search/_image_row.html.haml
+++ b/app/views/search/_image_row.html.haml
@@ -14,10 +14,10 @@
       = hidden_field_tag 'app[image]', presenter.title
       = label 'app[tag]', 'Tag:'
       = select_tag 'app[tag]',
-        options_for_select(['latest']),
+        remote ? options_for_select(['latest']) : presenter.tag_options,
         id: nil,
         class: 'image-tag-select',
-        data: {'load-tags-endpoint' => load_tags_search_path, 'loaded' => false}
+        data: {'load-tags-endpoint' => load_tags_search_path, 'loaded' => !remote}
       %button.button-positive{ data: { disable_with: 'Starting App...', tracking: { method: 'click', action: 'Create Application', category: 'Run Image', label: presenter.title }}} Run Image
   - if remote
     .community-data

--- a/app/views/search/_modal_image_row.html.haml
+++ b/app/views/search/_modal_image_row.html.haml
@@ -15,10 +15,10 @@
       = hidden_field_tag 'name', presenter.title
       = label 'app[tag]', 'Tag:'
       = select_tag 'app[tag]',
-      options_for_select(['latest']),
-      id: nil,
-      class: 'image-tag-select',
-      data: {'load-tags-endpoint' => load_tags_search_path, 'loaded' => false}
+        remote ? options_for_select(['latest']) : presenter.tag_options,
+        id: nil,
+        class: 'image-tag-select',
+        data: {'load-tags-endpoint' => load_tags_search_path, 'loaded' => !remote}
       %button.button-positive{ data: { disable_with: 'Adding...', tracking: { method: 'click', action: 'Add to Application', category: 'Run Image', label: presenter.title }}} Add to App
   - if remote
     .community-data

--- a/app/views/search/show.html.haml
+++ b/app/views/search/show.html.haml
@@ -8,7 +8,7 @@
 %h3.search-title Images
 .local-image-results
   - @search_result_set.local_images.each do |image|
-    = render 'image_row', {presenter: ImagePresenter.new(image)}
+    = render 'image_row', {presenter: ImagePresenter.new(image, self)}
 .remote-image-results
   - @search_result_set.remote_images.each do |image|
-    = render 'image_row', {presenter: ImagePresenter.new(image), remote: true}
+    = render 'image_row', {presenter: ImagePresenter.new(image, self), remote: true}

--- a/spec/javascripts/template_helpers/options_for_select_spec.js
+++ b/spec/javascripts/template_helpers/options_for_select_spec.js
@@ -1,0 +1,13 @@
+describe('optionsForSelect', function() {
+  var subject;
+
+  beforeEach(function() {
+    subject = Handlebars.helpers.optionsForSelect;
+  });
+
+  it('renders <option> tags for each item in the provided array', function() {
+    result = subject(['foo', 'bar']);
+    expect(result).toBe(
+      '<option value="foo">foo</option><option value="bar">bar</option>');
+  });
+});

--- a/spec/presenters/image_presenter_spec.rb
+++ b/spec/presenters/image_presenter_spec.rb
@@ -1,9 +1,11 @@
 require 'spec_helper'
 
 describe ImagePresenter do
+
   let(:fake_image) do
     double(:fake_image,
       source: 'boom/shaka',
+      tags: ['foo', 'bar'],
       description: 'goes boom shaka laka',
       short_description: 'goes boom',
       status_label: 'Local',
@@ -13,7 +15,9 @@ describe ImagePresenter do
     )
   end
 
-  subject { ImagePresenter.new(fake_image) }
+  let(:view_context) { ActionView::Base.new }
+
+  subject { ImagePresenter.new(fake_image, view_context) }
 
   describe '#title' do
     it 'exposes the image repository' do
@@ -48,6 +52,14 @@ describe ImagePresenter do
   describe '#docker_index_url' do
     it 'exposes the docker index url' do
       expect(subject.docker_index_url).to eq 'index.docker/boom/shaka'
+    end
+  end
+
+  describe '#tag_options' do
+    it 'returns a set of HTML options for each tag' do
+      expected =
+        "<option value=\"foo\">foo</option>\n<option value=\"bar\">bar</option>"
+      expect(subject.tag_options).to eq expected
     end
   end
 end

--- a/spec/presenters/json_image_presenter_spec.rb
+++ b/spec/presenters/json_image_presenter_spec.rb
@@ -42,4 +42,10 @@ describe JsonImagePresenter do
       expect(subject.badge_class).to eq '{{badge_class}}'
     end
   end
+
+  describe '#tag_options' do
+    it 'exposes handlebar template for the tag options' do
+      expect(subject.tag_options).to eq '{{{optionsForSelect tags}}}'
+    end
+  end
 end


### PR DESCRIPTION
Instead of relying on an AJAX callback to retrieve tags for local image search results, we're going to just render them directly (since they are now being returned as part of the search results themselves).

The key change here is the introduction of a Handlebars helper which will iterate over the list of tags associated with an image and populate the `<option>`s for the tag dropdown. There are also some changes in the `_image_row` partial to account for the fact that local and remote images are now treated differently (we still need to rely on AJAX to pull the list of tags for remote images).

[finishes #76102652]

Signed-off-by: Alex Welch me@alexwelch.com
