### PR TITLE
add a spec to catch missing semicolons in js files

### DIFF
--- a/app/assets/javascripts/jquery.context_help.js
+++ b/app/assets/javascripts/jquery.context_help.js
@@ -82,7 +82,7 @@
     base.closeContent = function() {
       base.$el.removeClass('viewing');
       base.$el.find(base.options.contentSelector).hide();
-    }
+    };
   };
 
   $.fn.contextHelp = function (options) {

--- a/app/assets/javascripts/jquery.error.interceptor.js
+++ b/app/assets/javascripts/jquery.error.interceptor.js
@@ -19,12 +19,12 @@
     base.handleError = function( event, jqxhr, settings, thrownError) {
       if (base.notExcludedUrl(settings.url) && jqxhr.status !== abortedStatus) {
         base.renderNotification(thrownError);
-      };
+      }
     };
 
     base.notExcludedUrl = function(url) {
       for(var i=0; i<base.options.excludePaths.length; i++) {
-        if (url.lastIndexOf(base.options.excludePaths[i]) !== -1) return false;
+        if (url.lastIndexOf(base.options.excludePaths[i]) !== -1) { return false; }
       }
       return true;
     };

--- a/app/assets/javascripts/jquery.filterable_list.js
+++ b/app/assets/javascripts/jquery.filterable_list.js
@@ -160,7 +160,7 @@
 
       $actionsFormSubmit.click();
       base.handleClose();
-    }
+    };
   };
 
   $.PMX.FilterableList = function(el, options) {
@@ -201,7 +201,7 @@
       base.queryField.onChange(base.fetchResults);
       base.$el.on('submit', base.options.queryFormSelector, base.handleSubmit);
       base.$el.on('click', base.options.chosenDropdownSelector, base.fetchTags);
-      base.$el.on('click', base.options.templateDetailsSelector, base.handleTemplateDetailsClick)
+      base.$el.on('click', base.options.templateDetailsSelector, base.handleTemplateDetailsClick);
     };
 
     base.handleSubmit = function(e) {

--- a/app/assets/javascripts/jquery.service_actions.js
+++ b/app/assets/javascripts/jquery.service_actions.js
@@ -48,7 +48,7 @@
     base.showServiceName = function () {
       if ($(base.options.$serviceLink).html().length > 24) {
         $('<span class="tooltip">' + base.options.$serviceLink.html() + '</span>').appendTo(base.$el);
-      };
+      }
     };
 
     base.hideServiceName = function () {

--- a/spec/syntax/js_syntax_spec.rb
+++ b/spec/syntax/js_syntax_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+require 'jshintrb'
+
+describe 'javascript syntax' do
+  JS_HINT_OPTIONS = {
+    bitwise: true,
+    curly: true,
+    eqeqeq: true,
+    forin: true,
+    immed: true,
+    latedef: true,
+    newcap: true,
+    noarg: true,
+    noempty: true,
+    nonew: true,
+    plusplus: true,
+    regexp: true,
+    undef: false,
+    strict: false,
+    trailing: true,
+    browser: true
+  }
+
+  def find_by_reason(results, reason)
+    results.detect do |result|
+      result['reason'] == reason
+    end.to_a
+  end
+
+  Dir.glob('app/**/*.js').each do |file|
+    describe "format for #{file}" do
+      let(:contents) { File.read(file) }
+      let(:results) { Jshintrb.lint(contents, JS_HINT_OPTIONS) }
+
+      it 'has no missing semicolons' do
+        expect(find_by_reason(results, 'Missing semicolon.')).to eq []
+      end
+
+      it 'has no unnecessary semicolons' do
+        expect(find_by_reason(results, 'Unnecessary semicolon.')).to eq []
+      end
+    end
+  end
+end


### PR DESCRIPTION
noticed we're still missing semicolons, so I cobbled together a spec to catch them. We could do the same thing for other jshint errors as well.
