### PR TITLE
Log to stdout in production mode

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,4 +83,15 @@ Rails.application.configure do
 
   # Use default logging formatter so that PID and timestamp are not suppressed.
   config.log_formatter = ::Logger::Formatter.new
+
+  config.before_initialize do
+    log_level = (ENV['LOG_LEVEL'] || config.log_level).to_s.upcase
+
+    STDOUT.sync = true
+    logger = ActiveSupport::TaggedLogging.new(Logger.new(STDOUT))
+    logger.level = Logger.const_get(log_level)
+    logger.formatter = config.log_formatter
+
+    ::Rails.logger = config.logger = logger
+  end
 end


### PR DESCRIPTION
Sets-up the Rails logger to write to `STDOUT` when running in production mode. This will help with production debugging as we'll be able to see the Rails logs via the `docker logs` command. Has the added benefit of making us more 12-factor compliant (http://12factor.net/logs).

The log level can now be set via an environment variable which should make it easy to crank the log level up without having to change any code inside the image.

[finishes #76164050]
