### PR TITLE
updated link text and added CoreOS host

### DIFF
--- a/app/views/apps/show.html.haml
+++ b/app/views/apps/show.html.haml
@@ -27,11 +27,11 @@
             %aside.arrow
             %span{ class: 'dismiss' }
             %p
-              If your application has a GUI, map a port on your local host machine to the port bound to the host.
+              If your application has a GUI, map a port on your local host machine to the port bound to the CoreOS host.
             %p
-              Go to our wiki for instructions.
-              %a{href:'https://github.com/CenturyLinkLabs/panamax-ui/wiki/How-To%3A-Port-Forwarding-on-VirtualBox'}
-                https://github.com/CenturyLinkLabs/panamax-ui/wiki/How-To%3A-Port-Forwarding-on-VirtualBox
+              = succeed '.' do
+                %a{href:'https://github.com/CenturyLinkLabs/panamax-ui/wiki/How-To%3A-Port-Forwarding-on-VirtualBox'}
+                  Go to our wiki for instructions
 
   = render 'application_button_menu', app: @app
 


### PR DESCRIPTION
Changed the link text to "Go to our wiki for instructions" and added CoreOS to host line.
