### PR TITLE
exposed port blank value filter

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -84,6 +84,7 @@ class Service < BaseResource
 
   def exposed_ports_attributes=(attributes)
     self.expose = attributes.each_with_object([]) do |(_, exposed_port), memo|
+      exposed_port['_deleted'] = 1 if exposed_port['port_number'].blank?
       memo << exposed_port['port_number'] unless exposed_port['_deleted'].to_s == '1'
     end
   end

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -279,6 +279,25 @@ describe Service do
     end
   end
 
+  describe '#exposed_ports_attributes=' do
+    let(:attributes) do
+      {
+        '0' => { 'port_number' => '111', '_deleted' => false },
+        '1' => { 'port_number' => '222', '_deleted' => 1 },
+        '2' => { 'port_number' => '', '_deleted' => false }
+      }
+    end
+
+    before do
+      subject.exposed_ports_attributes = attributes
+    end
+
+    it 'assigns exposed ports when the port_number is valid' do
+      expect(subject.exposed_ports.size).to be 1
+      expect(subject.exposed_ports.first['port_number']).to eq '111'
+    end
+  end
+
   describe '#environment_attributes=' do
     let(:attributes) do
       {


### PR DESCRIPTION
removes empty expose ports so they will not be included in submit to service layer
This is more UI enhancement. When users create many blank expose ports they can submit and not receive errors for empty expose ports they neglected to cancel.
