### PR TITLE
Update label in template search results

### DIFF
--- a/app/views/search/_template_row.html.haml
+++ b/app/views/search/_template_row.html.haml
@@ -8,7 +8,7 @@
     %p
       = presenter.short_description
       %a{href:"/templates/#{presenter.id}/details", class: "template-details-link" } More Details
-    %p.microcopy= "Last Updated: #{presenter.last_updated_on}"
+    %p.microcopy= "Source Last Refreshed: #{presenter.last_updated_on} UTC"
   .actions
     = form_tag apps_path do
       = hidden_field_tag 'app[template_id]', presenter.id

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -24,6 +24,7 @@ describe 'searching for templates and images' do
       expect(page).to have_content 'a wordpress template'
       expect(page).to have_content 'More Details'
       expect(page).to have_css '.image-count', text: '2 Images'
+      expect(page).to have_css '.microcopy', text: 'UTC'
       expect(page).to have_css 'img[src="/assets/type_icons/wordpress.svg"]'
 
       # source template repo blurb


### PR DESCRIPTION
Both the updated_at and created_at values refer to the last time the source repository was refreshed, so change the language in the search results to reflect that.

[finishes #78382346]
