### PR TITLE
Add error handling to check for valid user github data

### DIFF
--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -4,6 +4,12 @@ class TemplatesController < ApplicationController
   def new
     if app = App.find_by_id(params[:app_id])
       @user = User.find
+      if !@user.has_valid_github_creds?
+        flash.now[:alert] = "Your token may be malformed, expired or is not scoped correctly.
+Please <a href='https://github.com/settings/tokens/new?scope=repo,user:email' target='_blank'>
+generate a Github access token</a> with the correct privileges. Be sure to select at least 'repo'
+and 'user:email'."
+      end
       @template_form = TemplateForm.new(
         types: Type.all,
         user: @user,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -5,10 +5,17 @@ class User < BaseResource
     string :email
     boolean :github_access_token_present
     string :github_access_token
+    string :github_username
     boolean :subscribe
   end
 
   def repositories
     self.respond_to?(:repos) ? repos : []
   end
+
+  def has_valid_github_creds?
+    self.github_access_token_present? && self.email.present? && self.github_username.present?
+  end
+
+
 end

--- a/app/views/templates/new.html.haml
+++ b/app/views/templates/new.html.haml
@@ -3,7 +3,7 @@
 = render 'shared/errors', errors: @template_form.errors
 
 %h1 Save as Template
-- if @user.github_access_token_present?
+- if @user.has_valid_github_creds?
   = render 'form', template_form: @template_form
 
 - else

--- a/spec/features/manage_templates_spec.rb
+++ b/spec/features/manage_templates_spec.rb
@@ -61,6 +61,61 @@ describe 'managing a template' do
           expect(page).to have_content 'Save as Template'
         end
       end
+
+      context 'when user does not have an email' do
+
+        before do
+          user = User.new(github_access_token_present: true, email: '', github_username: 'bar')
+          User.stub(:find).and_return(user)
+          user.stub(:update_attributes).and_return(true)
+        end
+
+        it 'allows the user to request and enter a token' do
+
+          visit '/templates/new?app_id=1'
+
+          expect(page).to have_link(
+                              'Generate a Github access token',
+                              href: 'https://github.com/settings/tokens/new?scope=repo,user:email'
+                          )
+
+          expect(page).to have_unchecked_field 'user_subscribe'
+          expect(page).to have_content 'Sign up for our newsletter - Get all the latest news'
+
+          fill_in 'Github Token', with: 'abc123'
+          click_on 'Save Token'
+
+          expect(page).to have_content 'Save as Template'
+        end
+      end
+
+      context 'when user does not have a github username' do
+
+        before do
+          user = User.new(github_access_token_present: true, email: 'foo', github_username: '')
+          User.stub(:find).and_return(user)
+          user.stub(:update_attributes).and_return(true)
+        end
+
+        it 'allows the user to request and enter a token' do
+
+          visit '/templates/new?app_id=1'
+
+          expect(page).to have_link(
+                              'Generate a Github access token',
+                              href: 'https://github.com/settings/tokens/new?scope=repo,user:email'
+                          )
+
+          expect(page).to have_unchecked_field 'user_subscribe'
+          expect(page).to have_content 'Sign up for our newsletter - Get all the latest news'
+
+          fill_in 'Github Token', with: 'abc123'
+          click_on 'Save Token'
+
+          expect(page).to have_content 'Save as Template'
+        end
+      end
+
     end
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -7,6 +7,7 @@ describe User do
 
   it { should respond_to :email }
   it { should respond_to :github_access_token_present }
+  it { should respond_to :github_username }
   it { should respond_to :subscribe }
 
   describe '#repositories' do
@@ -19,5 +20,36 @@ describe User do
     it 'exists to satisfy form_for, but always returns nil' do
       expect(subject.github_access_token).to be_nil
     end
+  end
+
+  describe '#has_valid_github_creds?' do
+    context 'when all github creds are valid' do
+      let(:fake_user) { User.new(github_access_token_present: true, email: 'foo', github_username: 'bar') }
+      it 'returns true' do
+        expect(fake_user.has_valid_github_creds?).to be_true
+      end
+    end
+
+    context 'when github access token is not valid' do
+      let(:fake_user) { User.new(github_access_token_present: false, email: 'foo', github_username: 'bar') }
+      it 'returns false' do
+        expect(fake_user.has_valid_github_creds?).to be_false
+      end
+    end
+
+    context 'when user email is not valid' do
+      let(:fake_user) { User.new(github_access_token_present: true, email: '', github_username: 'bar') }
+      it 'returns false' do
+        expect(fake_user.has_valid_github_creds?).to be_false
+      end
+    end
+
+    context 'when github username is not valid' do
+      let(:fake_user) { User.new(github_access_token_present: true, email: 'foo', github_username: '') }
+      it 'returns false' do
+        expect(fake_user.has_valid_github_creds?).to be_false
+      end
+    end
+
   end
 end


### PR DESCRIPTION
Fixes [#76138136] [#80292266]

Check for valid user github token, email and username, before rendering the save as template form. If any of the data is missing, display an alert to the user, and take them to the new github token screen.
