### PR TITLE
Omit port['host_name'] if no value is given

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -64,7 +64,11 @@ class Service < BaseResource
 
   def ports_attributes=(attributes)
     self.ports = attributes.each_with_object([]) do |(_, port), memo|
-      memo << Port.new(port.except('id')) unless port['_deleted'].to_s == '1'
+      unless port['_deleted'].to_s == '1'
+        excludes = ['id']
+        excludes << 'host_port' if port['host_port'].blank?
+        memo << Port.new(port.except(*excludes))
+      end
     end
   end
 

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -259,7 +259,7 @@ describe Service do
       {
         '0' => { 'host_port' => 9090, 'container_port' => 90, 'proto' => 'TCP', '_deleted' => false },
         '1' => { 'host_port' => 8080, 'container_port' => 70, 'proto' => 'TCP', '_deleted' => 1 },
-        '2' => { 'host_port' => 6060, 'container_port' => 60, 'proto' => 'TCP', 'id' => nil, '_deleted' => false }
+        '2' => { 'host_port' => nil, 'container_port' => 60, 'proto' => 'TCP', 'id' => nil, '_deleted' => false }
       }
     end
 
@@ -276,6 +276,11 @@ describe Service do
     it 'excludes the id' do
       subject.ports_attributes = attributes
       expect(subject.ports.last.attributes.keys).to_not include 'id'
+    end
+
+    it 'excludes the host_port if the value is empty' do
+      subject.ports_attributes = attributes
+      expect(subject.ports.last.attributes.keys).to_not include 'host_port'
     end
   end
 


### PR DESCRIPTION
Host port is optional, so we shouldn't pass it to the API if the user does not specify a value.

[fixes #79313728]
