### PR TITLE
show ports exposed by base image

### DIFF
--- a/app/assets/stylesheets/panamax/service_details.scss
+++ b/app/assets/stylesheets/panamax/service_details.scss
@@ -290,7 +290,6 @@
       width: 23%;
       padding-right: 0px;
     }
-
   }
 
   .exposed-ports {
@@ -300,6 +299,15 @@
     input[type='number'] {
       @include border-box;
       width: 68px;
+    }
+
+    .info {
+      width: 60px;
+      float: right;
+      font-size: 10px;
+      color: #ccc;
+      font-style: italic;
+      margin-top: -6px;
     }
   }
 

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -120,6 +120,13 @@ class Service < BaseResource
     end
   end
 
+  def default_ports
+    self.default_exposed_ports.each_with_object([]) do |port, memo|
+      port_number, protocol = port.split('/')
+      memo << OpenStruct.new({port_number: port_number, proto: protocol})
+    end
+  end
+
   def self.build_from_response(response)
     attributes = JSON.parse(response)
     self.new(attributes)

--- a/app/views/services/_exposed_ports.html.haml
+++ b/app/views/services/_exposed_ports.html.haml
@@ -2,6 +2,12 @@
   %h4 Exposed Ports
 
   %ul
+    - @service.default_ports.each do |p|
+      %li
+        #{p.port_number}/#{p.proto}
+        .info
+          exposed by base image
+
     = f.fields_for :exposed_ports do |port|
       - checkbox_id = "select_exposed_port_#{port.options[:child_index]}"
       %li

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -331,6 +331,22 @@ describe Service do
     end
   end
 
+  describe '#default_ports' do
+    it 'assigns the ports to an array' do
+      subject.default_exposed_ports = ['3000/tcp', '8888/tcp']
+      expect(subject.default_ports).to be_an(Array)
+      expect(subject.default_ports.length).to eq(2)
+    end
+
+    it 'includes both port_number and protocol' do
+      subject.default_exposed_ports = ['3000/tcp', '8888/tcp']
+      expect(subject.default_ports.first['port_number']).to eq '3000'
+      expect(subject.default_ports.first['proto']).to eq 'tcp'
+
+    end
+
+  end
+
   describe '#base_image_name' do
     it 'returns the base image name without any tag information' do
       subject.from = 'supercool/repository:foobar'

--- a/spec/support/fixtures/service_representation_1.json
+++ b/spec/support/fixtures/service_representation_1.json
@@ -48,5 +48,8 @@
     "name": "Web Tier",
     "position": 1
   }
+  ],
+  "default_exposed_ports": [
+    "3000/tcp"
   ]
 }

--- a/spec/support/fixtures/service_representation_2.json
+++ b/spec/support/fixtures/service_representation_2.json
@@ -38,5 +38,8 @@
     "id": 4,
     "name": "Web Tier"
   }
+  ],
+  "default_exposed_ports": [
+    "3000/tcp"
   ]
 }

--- a/spec/support/fixtures/service_representation_6.json
+++ b/spec/support/fixtures/service_representation_6.json
@@ -13,5 +13,8 @@
   "from": "panamax/panamax-docker-wordpress:latest",
   "expose": [
     80
+  ],
+  "default_exposed_ports": [
+    "3000/tcp"
   ]
 }


### PR DESCRIPTION
Show ports exposed via EXPOSE in the Dockerfile in the UI. The user is not allowed to delete this `--expose` entry, though they can bind the port to an endpoint using the port binding form.

[finishes #79045292]
