### PR TITLE
new ports layout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to this project will be documented in this file.
 
+Latest
+------------------
+
+### Added
+- Port management
+ - Show ports exposed by the base image in list (#368)
+ - Table-based layout for ports information (#369)
+ 
+
 0.2.2 - 2014-09-26
 ------------------
 

--- a/app/assets/stylesheets/panamax/service_details.scss
+++ b/app/assets/stylesheets/panamax/service_details.scss
@@ -206,7 +206,8 @@
   ul li:hover .actions,
   dl dt:hover + dd + .actions,
   dl dd:hover + .actions,
-  dl dd.actions:hover {
+  dl dd.actions:hover,
+  tr:hover .actions {
     > * {
       visibility: visible;
     }
@@ -258,17 +259,86 @@
 .port-detail {
   @extend .service-detail;
 
+  table {
+    width: 100%;
+    &.port-bindings {
+      colgroup {
+        col {
+          &.ports {
+            width: 40%;
+          }
+          &.actions {
+            width: 20%
+          }
+        }
+      }
+    }
+
+    &.exposed-ports {
+      colgroup {
+        col {
+          &.ports {
+            width: 100px;
+          }
+        }
+      }
+      tr td {
+        &:last-child {
+          margin-left: 0;
+
+          .actions {
+            position: relative;
+            top: 3px;
+            float: left;
+          }
+        }
+      }
+    }
+
+    thead th, tbody tr td {
+      padding: 15px 5px;
+      text-align: left;
+      @include border-box;
+    }
+    thead {
+      th {
+        color: $grey;
+        font-style: italic;
+      }
+    }
+    tr {
+      border-bottom: 1px solid #f1f1f1;
+      td {
+        font-weight: bold;
+        .view-action {
+          margin-left: 6px;
+        }
+
+        .info {
+          font-size: 10px;
+          color: #ccc;
+          font-style: italic;
+          font-weight: normal;
+          margin-top: -6px;
+        }
+
+        .actions {
+
+        }
+
+      }
+    }
+  }
+
   .port-detail-forms {
     overflow: hidden;
   }
 
-  .port-bindings {
-    float: left;
-    width: 65%;
+  div.port-bindings {
+    margin-bottom: 50px;
 
-    li.legend {
-      color: $grey;
-      font-style: italic;
+    a + a#copy-endpoint {
+      margin-left: 6px;
     }
 
     select {
@@ -290,25 +360,15 @@
       width: 23%;
       padding-right: 0px;
     }
+
   }
 
   .exposed-ports {
-    width: 32%;
-    float: right;
-
     input[type='number'] {
       @include border-box;
       width: 68px;
     }
 
-    .info {
-      width: 60px;
-      float: right;
-      font-size: 10px;
-      color: #ccc;
-      font-style: italic;
-      margin-top: -6px;
-    }
   }
 
   h4 {

--- a/app/views/services/_exposed_ports.html.haml
+++ b/app/views/services/_exposed_ports.html.haml
@@ -1,22 +1,34 @@
 .exposed-ports
   %h4 Exposed Ports
 
-  %ul
-    - @service.default_ports.each do |p|
-      %li
-        #{p.port_number}/#{p.proto}
-        .info
-          exposed by base image
+  %table.exposed-ports
+    %colgroup
+      %col.ports
+      %col
+    %thead
+      %tr
+        %th
+          port
+        %th
+    %tbody
+      - @service.default_ports.each do |p|
+        %tr.image-defined
+          %td
+            #{p.port_number} / #{p.proto.upcase}
+          %td
+            .info
+              exposed by base image
 
-    = f.fields_for :exposed_ports do |port|
-      - checkbox_id = "select_exposed_port_#{port.options[:child_index]}"
-      %li
-        %span.exposed-port= port.object.port_number
-        .actions
-          = port.check_box :_deleted, { id: checkbox_id }
-          = port.hidden_field :port_number
-          %a{class: 'delete-action', title: 'remove', data: { checkbox: { selector: "##{checkbox_id}" } } } remove
-
+      = f.fields_for :exposed_ports do |port|
+        %tr
+          - checkbox_id = "select_exposed_port_#{port.options[:child_index]}"
+          %td
+            #{port.object.port_number} / TCP
+          %td
+            .actions
+              = port.check_box :_deleted, { id: checkbox_id }
+              = port.hidden_field :port_number
+              %a{class: 'delete-action', title: 'remove', data: { checkbox: { selector: "##{checkbox_id}" } } } remove
   %ul.additional-entries
     %li.editing
       = add_fields_for(:exposed_ports, f, { child_index: '_replaceme_' }) do |builder|

--- a/app/views/services/_port_bindings.html.haml
+++ b/app/views/services/_port_bindings.html.haml
@@ -1,24 +1,41 @@
 .port-bindings
-  %h4 Port Bindings
-  %ul
-    %li.legend
-      host port: container port / protocol
-    = f.fields_for :ports do |port|
-      - checkbox_id = "select_port_binding_#{port.options[:child_index]}"
-      %li{title: "host: #{port.object.host_port},
-                  container: #{port.object.container_port},
-                  protocol: #{port.object.proto}"}
-        %strong.host-port= port.object.host_port
-        \:
-        %span.container-port= port.object.container_port
-        \/
-        %span.proto= port.object.proto
-        .actions
-          = port.check_box :_deleted, { id: checkbox_id }
-          = port.hidden_field :container_port
-          = port.hidden_field :host_port
-          = port.hidden_field :proto
-          %a{class: 'delete-action', title: 'remove', data: { checkbox: { selector: "##{checkbox_id}" } } } remove
+  %h4 Mapped Endpoints
+
+  %table.port-bindings
+    %colgroup
+      %col.ports
+      %col
+      %col.actions
+    %thead
+      %tr
+        %th
+          host : container / protocol
+        %th
+          mapped endpoint
+        %th
+    %tbody
+      = f.fields_for :ports do |port|
+        - checkbox_id = "select_port_binding_#{port.options[:child_index]}"
+        %tr
+          %td{title: "host: #{port.object.host_port},
+                      container: #{port.object.container_port},
+                      protocol: #{port.object.proto}"}
+            %span.container_port= port.object.host_port
+            \:
+            %span.container-port= port.object.container_port
+            \/
+            %span.proto= port.object.proto
+          %td
+            = "https://#{request.env['SERVER_NAME']}:#{port.object.host_port}"
+            = link_to 'View', "https://#{request.env['SERVER_NAME']}:#{port.object.host_port}", target: 'blank', class: 'view-action'
+          %td
+            .actions
+              = port.check_box :_deleted, { id: checkbox_id }
+              = port.hidden_field :container_port
+              = port.hidden_field :host_port
+              = port.hidden_field :proto
+              %a{class: 'delete-action', title: 'remove', data: { checkbox: { selector: "##{checkbox_id}" } } } remove
+
   %ul.additional-entries
     %li.editing
       = add_fields_for(:ports, f, { child_index: '_replaceme_' }) do |builder|


### PR DESCRIPTION
Change the ports section to tables.

Note: adding the dynamically added host port and wiring up the "copy" button is in a separate story.

![image](https://cloud.githubusercontent.com/assets/775634/4406269/a47ed994-44c1-11e4-99b2-e22a53c09fba.png)
