### PR TITLE
initial helper for optional host_directory

### DIFF
--- a/app/assets/stylesheets/panamax/service_details.scss
+++ b/app/assets/stylesheets/panamax/service_details.scss
@@ -11,6 +11,12 @@
     padding-left: 40px;
     padding-right: 20px;
   }
+
+  .note {
+    color: $grey;
+    text-transform: lowercase;
+    font-style: italic;
+  }
 }
 
 .service-help-icon {

--- a/app/helpers/volume_helper.rb
+++ b/app/helpers/volume_helper.rb
@@ -1,0 +1,9 @@
+module VolumeHelper
+  def optional_directory(directory, default='Undefined')
+    if directory.present?
+      content_tag(:strong, directory)
+    else
+      content_tag(:span, default, class: 'note')
+    end
+  end
+end

--- a/app/views/services/_volumes.html.haml
+++ b/app/views/services/_volumes.html.haml
@@ -21,7 +21,7 @@
     = f.fields_for :volumes do |volume|
       - checkbox_id = "select_volume_#{volume.options[:child_index]}"
       %li{ title: "host: #{volume.object.host_path}, container: #{volume.object.container_path}" }
-        %strong.host-path= volume.object.host_path
+        = optional_directory(volume.object.host_path)
         \:
         %span.container-path= volume.object.container_path
         .actions

--- a/spec/helpers/volume_helper_spec.rb
+++ b/spec/helpers/volume_helper_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+
+describe VolumeHelper do
+  describe '#optional_directory' do
+
+    describe 'when the parameter is empty' do
+
+      it 'returns a span tag with class note' do
+        result = optional_directory('')
+        expect(result).to include("<span class=\"note\">")
+      end
+
+      it 'set value to  Undefined by default' do
+        result = optional_directory('')
+        expect(result).to include('Undefined')
+      end
+
+      it 'uses default value when provided' do
+        result = optional_directory('', 'NOT')
+        expect(result).to include('NOT')
+      end
+    end
+
+    describe 'when a parameter is provided' do
+
+      it 'returns a strong tag with path value' do
+        result = optional_directory('my_path')
+        expect(result).to include('<strong>my_path</strong>')
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
Creates a helper to display a default text value when the provided value is not present. The default value will be styled different than a provided one. I thought about having the helper create the whole host : container line but this might be more useful as a generic optional value helper.
