### PR TITLE
Catch exceptions and show error when save template to repo fails.

### DIFF
--- a/app/forms/template_form.rb
+++ b/app/forms/template_form.rb
@@ -38,7 +38,12 @@ class TemplateForm
   def save
     @template = create_template
     if @template.valid?
-      save_template_to_repo(@template)
+      begin
+        save_template_to_repo(@template)
+      rescue => ex
+        self.errors.add(:repo, ex.message)
+        return false
+      end
     else
       self.errors.messages.merge!(@template.errors.messages)
       return false

--- a/spec/forms/template_form_spec.rb
+++ b/spec/forms/template_form_spec.rb
@@ -203,6 +203,32 @@ describe TemplateForm do
         expect(subject.errors.messages).to include(name: ['is invalid'])
       end
     end
+
+    context 'when token is unscoped for repo' do
+
+      let(:fake_template) { double(:fake_template, valid?: true) }
+
+      before do
+        Template.stub(:create).and_return(fake_template)
+        subject.stub(:save_template_to_repo).with(fake_template).and_raise('boom')
+      end
+
+      it 'adds an error for template form' do
+        subject.save
+        expect(subject.errors.count).to eq(1)
+      end
+
+      it 'display an error for the repo attribute' do
+        subject.save
+        expect(subject.errors.full_message(:repo, 'boom')).to eq('Repo boom')
+      end
+
+      it 'does not save the template to a repo' do
+        expect(Template.any_instance).to_not receive(:post)
+        subject.save
+      end
+
+    end
   end
 
 end


### PR DESCRIPTION
Fixes [#80215916]

This PR augments the API PR (https://github.com/CenturyLinkLabs/panamax-api/pull/218), to catch the exception raised by `save_template_to_repo`, and displays an error message to the user. Catching the exception here keeps the user on the Save as Template screen, and provides an appropriate context to the error message.
