### PR TITLE
Don't show token error msg for first time user

### DIFF
--- a/app/controllers/templates_controller.rb
+++ b/app/controllers/templates_controller.rb
@@ -4,7 +4,8 @@ class TemplatesController < ApplicationController
   def new
     if app = App.find_by_id(params[:app_id])
       @user = User.find
-      if !@user.has_valid_github_creds?
+      # don't show error if it is the first use
+      if @user.has_invalid_github_creds?
         flash.now[:alert] = "Your token may be malformed, expired or is not scoped correctly.
 Please <a href='https://github.com/settings/tokens/new?scope=repo,user:email' target='_blank'>
 generate a Github access token</a> with the correct privileges. Be sure to select at least 'repo'

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,5 +17,8 @@ class User < BaseResource
     self.github_access_token_present? && self.email.present? && self.github_username.present?
   end
 
+  def has_invalid_github_creds?
+    self.github_access_token_present? && self.email.blank? && self.github_username.blank?
+  end
 
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -23,33 +23,119 @@ describe User do
   end
 
   describe '#has_valid_github_creds?' do
-    context 'when all github creds are valid' do
+    context 'when all github creds are present' do
       let(:fake_user) { User.new(github_access_token_present: true, email: 'foo', github_username: 'bar') }
       it 'returns true' do
         expect(fake_user.has_valid_github_creds?).to be_true
       end
     end
 
-    context 'when github access token is not valid' do
-      let(:fake_user) { User.new(github_access_token_present: false, email: 'foo', github_username: 'bar') }
-      it 'returns false' do
-        expect(fake_user.has_valid_github_creds?).to be_false
-      end
-    end
-
-    context 'when user email is not valid' do
-      let(:fake_user) { User.new(github_access_token_present: true, email: '', github_username: 'bar') }
-      it 'returns false' do
-        expect(fake_user.has_valid_github_creds?).to be_false
-      end
-    end
-
-    context 'when github username is not valid' do
+    context 'when github username is not present' do
       let(:fake_user) { User.new(github_access_token_present: true, email: 'foo', github_username: '') }
       it 'returns false' do
         expect(fake_user.has_valid_github_creds?).to be_false
       end
     end
 
+    context 'when only user email is not present' do
+      let(:fake_user) { User.new(github_access_token_present: true, email: '', github_username: 'bar') }
+      it 'returns false' do
+        expect(fake_user.has_valid_github_creds?).to be_false
+      end
+    end
+
+    context 'when only github token is not present' do
+      let(:fake_user) { User.new(github_access_token_present: false, email: 'foo', github_username: 'bar') }
+      it 'returns false' do
+        expect(fake_user.has_valid_github_creds?).to be_false
+      end
+    end
+
+    context 'when only github token is present' do
+      let(:fake_user) { User.new(github_access_token_present: true, email: '', github_username: '') }
+      it 'returns false' do
+        expect(fake_user.has_valid_github_creds?).to be_false
+      end
+    end
+
+    context 'when only email is present' do
+      let(:fake_user) { User.new(github_access_token_present: false, email: 'foo', github_username: '') }
+      it 'returns false' do
+        expect(fake_user.has_valid_github_creds?).to be_false
+      end
+    end
+
+    context 'when only github username is present' do
+      let(:fake_user) { User.new(github_access_token_present: false, email: '', github_username: 'bar') }
+      it 'returns false' do
+        expect(fake_user.has_valid_github_creds?).to be_false
+      end
+    end
+
+    context 'when all github creds are not present' do
+      let(:fake_user) { User.new(github_access_token_present: false, email: '', github_username: '') }
+      it 'returns false' do
+        expect(fake_user.has_valid_github_creds?).to be_false
+      end
+    end
   end
+
+  describe '#has_invalid_github_creds?' do
+    context 'when all github creds are present' do
+      let(:fake_user) { User.new(github_access_token_present: true, email: 'foo', github_username: 'bar') }
+      it 'returns false' do
+        expect(fake_user.has_invalid_github_creds?).to be_false
+      end
+    end
+
+    context 'when only github token is present' do
+      let(:fake_user) { User.new(github_access_token_present: true, email: nil, github_username: nil) }
+      it 'returns true' do
+        expect(fake_user.has_invalid_github_creds?).to be_true
+      end
+    end
+
+    context 'when only github token is not present' do
+      let(:fake_user) { User.new(github_access_token_present: false, email: 'foo', github_username: 'bar') }
+      it 'returns false' do
+        expect(fake_user.has_invalid_github_creds?).to be_false
+      end
+    end
+
+    context 'when only email is not present' do
+      let(:fake_user) { User.new(github_access_token_present: true, email: '', github_username: 'bar') }
+      it 'returns false' do
+        expect(fake_user.has_invalid_github_creds?).to be_false
+      end
+    end
+
+    context 'when only github username is not present' do
+      let(:fake_user) { User.new(github_access_token_present: true, email: 'foo', github_username: '') }
+      it 'returns false' do
+        expect(fake_user.has_invalid_github_creds?).to be_false
+      end
+    end
+
+    context 'when only user name is present' do
+      let(:fake_user) { User.new(github_access_token_present: false, email: '', github_username: 'bar') }
+      it 'returns false' do
+        expect(fake_user.has_invalid_github_creds?).to be_false
+      end
+    end
+
+    context 'when only email is present' do
+      let(:fake_user) { User.new(github_access_token_present: false, email: 'foo', github_username: '') }
+      it 'returns false' do
+        expect(fake_user.has_invalid_github_creds?).to be_false
+      end
+    end
+
+    context 'when all github creds are not present' do
+      let(:fake_user) { User.new(github_access_token_present: false, email: nil, github_username: nil) }
+      it 'returns false' do
+        expect(fake_user.has_invalid_github_creds?).to be_false
+      end
+    end
+  end
+
 end


### PR DESCRIPTION
Fixes [#80399122]

Fix to not show error message on Save as Template page, for missing github token when user comes in for the first time.

For testing, make sure you follow these steps:
1. Rebuild your db, so Github token is nil.
2. Create an application, and try to save as template.
3. You should see the New Github Token page but no error message.
4. Paste in your valid Github token. Optionally, save the template.
5. Regenerate your Github token.
6. Go to your application, and try to save as template.
7. You should see the New Github Token page but this time you should see an error message.
8. Paste in your new token. Optionally, save the template.
