### PR TITLE
Moving these shared examples to the proper place.

### DIFF
--- a/spec/support/shared/cadvisor_measurable_example.rb
+++ b/spec/support/shared/cadvisor_measurable_example.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-shared_examples_for "cadvisor_measurable" do
+shared_examples_for 'cadvisor_measurable' do
   before do
     MachineInfo.stub(:find).and_return(MachineInfo.new({ num_cores: 2, memory_capacity: 1000 }))
   end


### PR DESCRIPTION
This fixes the issue when trying to run:
spec/models/host_health_spec.rb in isolation.
