### PR TITLE
add message for remote deployment

### DIFF
--- a/app/views/services/_exposed_ports.html.haml
+++ b/app/views/services/_exposed_ports.html.haml
@@ -17,7 +17,7 @@
             #{p.port_number} / #{p.proto.upcase}
           %td
             .info
-              exposed by base image
+              exposed by base image - remote deployment will require explicit port declaration
 
       = f.fields_for :exposed_ports do |port|
         %tr


### PR DESCRIPTION
Remote deployments will require an explicit expose port for service discovery to work correctly when a base image exposes a port. This message is an indicator for the user.
