### PR TITLE
Be quiet about coverage locally.

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -5,22 +5,25 @@ require 'rspec/rails'
 require 'rspec/autorun'
 require 'capybara/rails'
 require 'webmock/rspec'
-require 'coveralls'
-require 'simplecov'
+
+if ENV['CIRCLE_ARTIFACTS'] || ENV['COVERAGE'].present?
+  require 'coveralls'
+  require 'simplecov'
+
+  SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
+      SimpleCov::Formatter::HTMLFormatter,
+      Coveralls::SimpleCov::Formatter
+  ]
+
+  SimpleCov.start('rails')
+
+  if ENV['CIRCLE_ARTIFACTS']
+    dir = File.join('..', '..', '..', ENV['CIRCLE_ARTIFACTS'], 'coverage')
+    SimpleCov.coverage_dir(dir)
+  end
+end
 
 DOCKER_INDEX_BASE_URL = 'https://registry.hub.docker.com/'
-
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-    SimpleCov::Formatter::HTMLFormatter,
-    Coveralls::SimpleCov::Formatter
-]
-
-SimpleCov.start('rails')
-
-if ENV['CIRCLE_ARTIFACTS']
-  dir = File.join('..', '..', '..', ENV['CIRCLE_ARTIFACTS'], 'coverage')
-  SimpleCov.coverage_dir(dir)
-end
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
I certainly don't have a strong opinion about this, but I'm not a fan of the extra chatter in my test runs about coverage (particularly the jarring yellow **Outside of Travis, not sending data** stuff that makes me think I accidentally left a spec pending).

This PR makes it go away locally. Anybody care one way or another? You can still run it as-is by passing `COVERAGE=true` in your rspec command if you really want to check the coverage locally yourself. If this does get approved I will probably do the same thing in API.
