### PR TITLE
remove the smaller height on deployment tabs

### DIFF
--- a/app/assets/stylesheets/panamax/deployments.css.scss
+++ b/app/assets/stylesheets/panamax/deployments.css.scss
@@ -66,10 +66,6 @@
       padding-bottom: 30px;
       margin-bottom: 20px;
 
-      .content {
-        min-height: 320px;
-      }
-
       .expand {
         padding-left: 20px;
         position: relative;


### PR DESCRIPTION
The smaller min height closed some white space but with the updated slide transition the overflow-y creates scroll on the option dropdown.

![screen shot 2014-11-07 at 9 18 42 am](https://cloud.githubusercontent.com/assets/923211/4955069/84711700-6692-11e4-928e-a5139a56cf37.png)
