### PR TITLE
override relative positioning on dialog styles

### DIFF
--- a/app/assets/javascripts/jquery.select_deployment_target.js
+++ b/app/assets/javascripts/jquery.select_deployment_target.js
@@ -10,7 +10,8 @@
 
     base.defaultOptions = {
       targetSelector: '.select-deployment-target',
-      filterSelector: '.select-remote-target'
+      filterSelector: '.select-remote-target',
+      dialogContentSelector: '.ui-dialog-content'
     };
 
 
@@ -47,7 +48,11 @@
       targetDialog = $.PMX.Helpers.dialog(base,$contents, {
         title: 'Select Remote Deployment Target'
       });
+
       targetDialog.dialog('open');
+
+      // must set height here or jQueryUI sets inline style to auto
+      $contents.css('height', ($contents.height() + 20) + 'px');
     };
 
     base.handleClose = function () {

--- a/app/assets/stylesheets/panamax.css.scss
+++ b/app/assets/stylesheets/panamax.css.scss
@@ -352,6 +352,10 @@ ul[class*='button-menu'] {
   margin-left: 5px;
 }
 
+.ui-dialog {
+  position:absolute;
+}
+
 // Confirm delete dialog
 
 .confirm-delete {


### PR DESCRIPTION
fixes height calculation on select deployment target dialog and the way jqueryUI uses position.
