### PR TITLE
refresh default_exposed_ports

### DIFF
--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -111,6 +111,8 @@
 
     $('table.port-bindings tbody tr').portMappings();
 
+    $('table.exposed-ports').exposedPorts();
+
     $('[data-accordian-expand]').accordian();
 
     $('body').toggleTargetClass();

--- a/app/assets/javascripts/jquery.exposed_ports.js
+++ b/app/assets/javascripts/jquery.exposed_ports.js
@@ -1,0 +1,77 @@
+(function($) {
+  $.PMX.ExposedPorts = function(el, options) {
+    var base = this;
+
+    base.$el = $(el);
+
+    base.defaultOptions = {
+      $exposedPortTableBody: base.$el.find('tbody'),
+      serviceStatusSelector: 'span.service-status'
+    };
+
+    base.init = function() {
+      base.options = $.extend({},base.defaultOptions, options);
+      base.bindEvents();
+    };
+
+    base.bindEvents = function () {
+      $(base.options.serviceStatusSelector).on('update-service-status', base.handleResponse);
+    };
+
+    base.handleResponse = function (_, response) {
+      var serviceIsRunning = response.sub_state === 'running' && response.load_state === 'loaded';
+
+      if (serviceIsRunning) {
+        base.updateExposedPorts(response);
+      }
+      else {
+        base.showLoadingMessage();
+      }
+    };
+
+    base.showLoadingMessage = function () {
+      if (base.$el.find('tr.loading').length === 0) {
+        base.options.$exposedPortTableBody.append(
+            '<tr class="loading"><td colspan="2">' +
+            'More port information may be available when service enters running state' +
+            '</td></tr>'
+        );
+      }
+    };
+
+    base.hideLoadingMessage = function () {
+      if (base.$el.find('tr.loading').length > 0) {
+        base.$el.find('tr.loading').remove();
+      }
+    };
+
+    base.formatPort = function (exposed_port) {
+      return exposed_port.replace("/", " / ").toUpperCase();
+    };
+
+    base.updateExposedPorts = function(response) {
+      base.hideLoadingMessage();
+      var exposed_ports = response.default_exposed_ports;
+
+      if ((base.$el.find('tr.image-defined').length == 0) && exposed_ports.length > 0) {
+        $.each(exposed_ports, function(index, exposed_port) {
+          var port = base.formatPort(exposed_port);
+          base.options.$exposedPortTableBody.append(
+              '<tr class="image-defined"><td>'+
+              port +
+              '</td><td><div class="info">' +
+              'exposed by base image - remote deployment will require explicit port declaration' +
+              '</div></td></tr>'
+          );
+        });
+      }
+    };
+  };
+
+  $.fn.exposedPorts = function(options) {
+    return this.each(function() {
+      (new $.PMX.ExposedPorts(this, options)).init();
+    });
+  };
+
+})(jQuery);

--- a/app/assets/stylesheets/panamax/service_details.scss
+++ b/app/assets/stylesheets/panamax/service_details.scss
@@ -333,14 +333,22 @@
           }
         }
       }
-      tr td {
-        &:last-child {
-          margin-left: 0;
+      tr {
+        &.loading {
+          td {
+            font-weight: normal;
+            color: #a1a1a1;
+          }
+        }
+        td {
+          &:last-child {
+            margin-left: 0;
 
-          .actions {
-            position: relative;
-            top: 3px;
-            float: left;
+            .actions {
+              position: relative;
+              top: 3px;
+              float: left;
+            }
           }
         }
       }

--- a/spec/javascripts/fixtures/exposed-ports-table.html.haml
+++ b/spec/javascripts/fixtures/exposed-ports-table.html.haml
@@ -1,0 +1,7 @@
+%span.service-status
+
+%table.exposed-ports
+  %tbody
+    %tr
+      %td
+      %td

--- a/spec/javascripts/jquery.exposed_ports_spec.js
+++ b/spec/javascripts/jquery.exposed_ports_spec.js
@@ -1,0 +1,153 @@
+describe('$.fn.exposedPorts', function() {
+  var subject,
+    $portMappings;
+
+  var serviceResponse = {
+    'sub_state': 'running',
+    'load_state': 'loaded',
+    'default_exposed_ports': ['3000/tcp']
+  };
+
+  var stoppedServiceResponse = {
+    'sub_state': 'stopped',
+    'load_state': 'foo'
+  };
+
+  var loadingServiceResponse = {
+    'sub_state': 'foo',
+    'load_state': 'loading'
+  };
+
+  beforeEach(function() {
+    fixture.load('exposed-ports-table.html');
+  });
+
+  describe('handleResponse', function() {
+
+    describe('when the service is running', function () {
+      it('removes the loading message from the table', function () {
+        $exposedPorts = $('#teaspoon-fixtures').find('table');
+        subject = new $.PMX.ExposedPorts($exposedPorts);
+        subject.init();
+        $('span.service-status').trigger('update-service-status', stoppedServiceResponse);
+        expect($('table.exposed-ports').find('tr.loading').length).toBe(1);
+
+        $('span.service-status').trigger('update-service-status', serviceResponse);
+        expect($('table.port-bindings').find('tr.loading').length).toBe(0);
+      });
+
+      it('calls updateExposedPorts', function() {
+        $exposedPorts = $('#teaspoon-fixtures').find('table');
+        subject = new $.PMX.ExposedPorts($exposedPorts);
+        subject.init();
+        spyOn(subject, 'updateExposedPorts');
+        $('span.service-status').trigger('update-service-status', serviceResponse);
+        expect(subject.updateExposedPorts).toHaveBeenCalledWith(serviceResponse);
+      });
+    });
+
+    describe('when the service is stopped', function () {
+      it('adds the loading message to the table', function () {
+        $exposedPorts = $('#teaspoon-fixtures').find('table');
+        subject = new $.PMX.ExposedPorts($exposedPorts);
+        subject.init();
+        $('span.service-status').trigger('update-service-status', stoppedServiceResponse);
+        expect($('table.exposed-ports').find('tr.loading').length).toBe(1);
+      });
+    });
+
+    describe('when the service is loading', function () {
+      it('adds the loading message to the table', function () {
+        $exposedPorts = $('#teaspoon-fixtures').find('table');
+        subject = new $.PMX.ExposedPorts($exposedPorts);
+        subject.init();
+        $('span.service-status').trigger('update-service-status', loadingServiceResponse);
+        expect($('table.exposed-ports').find('tr.loading').length).toBe(1);
+      });
+    });
+  });
+
+  describe('showLoadingMessage', function () {
+    it('adds the loading message to the table', function () {
+      $exposedPorts = $('#teaspoon-fixtures').find('table');
+      subject = new $.PMX.ExposedPorts($exposedPorts);
+      subject.init();
+      $('span.service-status').trigger('update-service-status', serviceResponse);
+      expect($('table.exposed-ports').find('tr.loading').length).toBe(0);
+
+      $('span.service-status').trigger('update-service-status', stoppedServiceResponse);
+      expect($('table.exposed-ports').find('tr.loading').length).toBe(1);
+    });
+
+  });
+
+  describe('hideLoadingMessage', function () {
+    it('removes the loading message from the table', function () {
+      $exposedPorts = $('#teaspoon-fixtures').find('table');
+      subject = new $.PMX.ExposedPorts($exposedPorts);
+      subject.init();
+      $('span.service-status').trigger('update-service-status', stoppedServiceResponse);
+      expect($('table.exposed-ports').find('tr.loading').length).toBe(1);
+
+      $('span.service-status').trigger('update-service-status', serviceResponse);
+      expect($('table.exposed-ports').find('tr.loading').length).toBe(0);
+    });
+  });
+
+  describe('updateExposedPorts', function () {
+    beforeEach(function () {
+      $exposedPorts = $('#teaspoon-fixtures').find('table');
+      subject = new $.PMX.ExposedPorts($exposedPorts);
+    });
+
+    it('removes the loading message from the table', function () {
+      subject.init();
+      $('span.service-status').trigger('update-service-status', stoppedServiceResponse);
+      expect($('table.exposed-ports').find('tr.loading').length).toBe(1);
+      $('span.service-status').trigger('update-service-status', serviceResponse);
+      expect($('table.exposed-ports').find('tr.loading').length).toBe(0);
+    });
+
+    it ('calls formatPort', function () {
+      subject.init();
+      spyOn(subject, 'formatPort').andReturn("3000 / TCP");
+      $('span.service-status').trigger('update-service-status', serviceResponse);
+      expect(subject.formatPort).toHaveBeenCalledWith(serviceResponse.default_exposed_ports[0]);
+    });
+
+    describe ('when default_exposed_ports exist in the table', function () {
+      it ('does not update the table', function () {
+        subject.init();
+        $('table.exposed-ports').append(
+            '<tr class="image-defined"><td>5432</td><td><div class="info">' +
+            'exposed by base image - remote deployment will require explicit port declaration</div></td></tr>'
+        );
+        beforeUpdate = $('table.exposed-ports').html();
+        $('span.service-status').trigger('update-service-status', serviceResponse);
+        expect($('table.exposed-ports').html()).toEqual(beforeUpdate);
+      });
+    });
+
+    describe ('when default_exposed_ports do not exist in the table', function () {
+      it ('adds port information', function () {
+        subject.init();
+        expect($('table.exposed-ports').find('.image-defined').length).toBe(0);;
+        $('span.service-status').trigger('update-service-status', serviceResponse);
+        expect($('table.exposed-ports').find('.image-defined').length).toBe(1);;
+      });
+    });
+  });
+
+  describe('formatPort', function () {
+    beforeEach(function () {
+      $exposedPorts = $('#teaspoon-fixtures').find('table');
+      subject = new $.PMX.ExposedPorts($exposedPorts);
+    });
+
+    it ('adds spacing and upcases the protocol', function () {
+      $('span.service-status').trigger('update-service-status', serviceResponse);
+      var result = subject.formatPort(serviceResponse.default_exposed_ports[0]);
+      expect(result).toEqual("3000 / TCP")
+    });
+  });
+});


### PR DESCRIPTION
If the user accesses the service details page before the image is done downloading, ports exposed by the image will not appear in the details. Adding default_exposed_ports to the plethora of things to be refreshed when the service enters running & loaded states.
