### PR TITLE
Fix issues with service environment variables.

### DIFF
--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -92,12 +92,6 @@
       inputKey: 'input[data-index=name_%]'
     });
 
-    $('.environment-variables dl.entries').editParameter({
-      fieldSelector: 'dd.variable-value span',
-      editSelector: 'dd.variable-value a.edit-action',
-      inputKey: 'input[data-index=value_%]'
-    });
-
     $('.journal-output').journalLoader();
 
     $('.journal-toggle').journalToggle();

--- a/app/assets/javascripts/jquery.docker_run/jquery.docker_run.js
+++ b/app/assets/javascripts/jquery.docker_run/jquery.docker_run.js
@@ -20,7 +20,7 @@
       exposedPortsSelector: '.exposed-ports .exposed-port:visible',
       environmentVarsSelector: '.environment-variables dl:visible',
       envVarNameSelector: '.variable-name',
-      envVarValueSelector: '.variable-value',
+      envVarValueSelector: '.variable-value input',
       volumesSelector: '.volumes > .data-containers > ul > li:visible',
       volumeHostPathSelector: '.host-path',
       volumeContainerPathSelector: '.container-path',

--- a/app/assets/javascripts/jquery.edit_parameter.js
+++ b/app/assets/javascripts/jquery.edit_parameter.js
@@ -35,6 +35,7 @@
           onRevert: base.handleRevert,
           editorPromise: base.completeEdit
         })).init();
+      base.overrideLabelClickBehavior();
     };
 
     base.handleRevert = function(e) {
@@ -50,8 +51,18 @@
       $(base.options.submitButton).removeAttr('disabled');
       $('body').trigger('progressiveForm:changed');
       transaction.resolve();
+      base.reinitializeDefaultClickBehavior();
 
       return transaction.promise();
+    };
+
+    base.overrideLabelClickBehavior = function() {
+      base.$el.on('click', function(e) { e.preventDefault(); });
+    };
+
+    base.reinitializeDefaultClickBehavior = function() {
+      base.$el.unbind('click');
+      base.bindEvents();
     };
 
   };

--- a/app/views/services/_environment_variables.html.haml
+++ b/app/views/services/_environment_variables.html.haml
@@ -21,18 +21,11 @@
           .actions
             %a{ class: 'edit-action' }
         %dd.variable-value
-          - if env_var.object.value.blank?
-            = env_var.text_field :value, placeholder: 'enter a value', class: 'empty', data: { index: "#{index}" }
-          - else
-            %span{ data: { index: "#{index}" } }
-              = env_var.object.value
-            .actions
-              %a{ class: 'edit-action' }
+          = env_var.text_field :value, placeholder: 'enter a value', data: { index: "#{index}" }
         %dd.actions
           - checkbox_id = "select_environment_variable_#{index}"
           = env_var.check_box :_deleted, { id: checkbox_id }
           = env_var.hidden_field :variable, data: { index: "name_#{index}" }
-          = env_var.hidden_field :value, data: { index: "value_#{index}" }
           %a{class: 'delete-action', title: 'remove', data: { checkbox: { selector: "##{checkbox_id}" } } } remove
 
     .additional-entries

--- a/spec/features/manage_service_spec.rb
+++ b/spec/features/manage_service_spec.rb
@@ -24,7 +24,7 @@ describe 'managing a service' do
         end
 
         within '.environment-variables', text: 'Environment Variables' do
-          expect(page).to have_content 'DB_PASSWORD pass@word01'
+          expect(page).to have_field('DB_PASSWORD', with: "pass@word01")
         end
 
         within '.service-links' do

--- a/spec/javascripts/fixtures/docker-run.html.haml
+++ b/spec/javascripts/fixtures/docker-run.html.haml
@@ -46,12 +46,12 @@
       %dt.variable-name
         PATH
       %dd.variable-value
-        \/tmp
+        %input{ value: '/tmp' }
     %dl
       %dt
         %input.variable-name{ value: 'DEBUG' }
-      %dd
-        %input.variable-value{ value: 'TRUE' }
+      %dd.variable-value
+        %input{ value: 'TRUE' }
   .volumes
     .data-containers
       %ul


### PR DESCRIPTION
In cases where the environment variable had no value in the template,
the interface made it impossible to set a value. It would be overwritten
by a hidden field, and the UI was otherwise broke in a few ways (field
still indicated it was empty and the docker run command never updated).
Move to straight inputs while allowing the label to remain a magic
editable thing (though some JS tweaks had to go in place to disable the
default behavior where a label being clicked would focus on its
associated input).
