### PR TITLE
changing Docker link on services#show

### DIFF
--- a/app/assets/stylesheets/panamax/service_details.scss
+++ b/app/assets/stylesheets/panamax/service_details.scss
@@ -197,11 +197,6 @@
     span {
       margin-right: 6px;
     }
-
-    .docker-link {
-      padding-left: 10px;
-      border-left: 1px solid $dark_grey;
-    }
   }
 
   .documentation {
@@ -211,6 +206,11 @@
     a {
       text-decoration: underline;
       font-size: 0.9em;
+      padding-right: 5px;
+      &:last-child {
+        padding-left: 10px;
+        border-left: 1px solid $dark_grey;
+      }
     }
   }
 }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -112,9 +112,8 @@ class Service < BaseResource
     categories.min_by { |category| category.id }.id
   end
 
-  def docker_index_url
-    path_part = "u/#{self.base_image_name}"
-    "#{DOCKER_INDEX_BASE_URL}#{path_part}"
+  def docker_search_url
+    "#{DOCKER_INDEX_BASE_URL}search?q=#{self.base_image_name}"
   end
 
   def as_json(options={})

--- a/app/views/services/show.html.haml
+++ b/app/views/services/show.html.haml
@@ -38,9 +38,9 @@
       %h6 Tag:
       %span
         = @service.image_tag_name
-      = link_to 'View on Docker Hub', @service.docker_index_url, { class: 'docker-link', target: 'blank', data: { 'tracking-method' => 'click', 'tracking-action' => 'View on Docker Hub', 'tracking-category' => 'Outbound Link', 'tracking-label' => @service.docker_index_url }}
     .documentation
       = link_to('Documentation', '#', { class: 'instructions-dialog', data: {'doc-url'=> documentation_app_path(@app.id)} })  if @app.documentation_to_html.present?
+      = link_to 'Find on Docker Hub', @service.docker_search_url, { target: 'blank', data: { 'tracking-method' => 'click', 'tracking-action' => 'Find on Docker Hub', 'tracking-category' => 'Outbound Link', 'tracking-label' => @service.docker_search_url }}
 
   = form_for [@app, @service], html: { class: 'service-edit-form' } do |f|
     = render 'shared/errors', errors: f.object.errors

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -406,10 +406,10 @@ describe Service do
     end
   end
 
-  describe '#docker_index_url' do
-    it 'composes a docker index URL' do
+  describe '#docker_search_url' do
+    it 'composes a docker search URL' do
       subject.from = 'supercool/repository'
-      expect(subject.docker_index_url).to eq "#{DOCKER_INDEX_BASE_URL}u/supercool/repository"
+      expect(subject.docker_search_url).to eq "#{DOCKER_INDEX_BASE_URL}search?q=supercool/repository"
     end
   end
 


### PR DESCRIPTION
A bit of CYA for privately-hosted or local images. The base image may still exist on the Hub so we want users to be able to find it, but this will prevent a 404 in case the image is not on the Hub.
