### PR TITLE
Fix show page on update failure

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -51,6 +51,7 @@ class ServicesController < ApplicationController
         format.json { render(json: @service.to_json, status: status) }
       end
     else
+      @service.reload
       render :show
     end
   end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -203,6 +203,12 @@ describe ServicesController do
     context 'when saving fails' do
       before do
         valid_service.stub(:save).and_return(false)
+        valid_service.stub(:reload).and_return(true)
+      end
+
+      it 'reloads the service' do
+        patch :update, app_id: 2, id: 3, service: attributes
+        expect(valid_service).to have_received(:reload)
       end
 
       it 're-renders the show page' do


### PR DESCRIPTION
This will prevent the erroneous attributes from being displayed in the UI, and it keeps the error messages intact.
