### PR TITLE
rehydrate linked services

### DIFF
--- a/app/controllers/services_controller.rb
+++ b/app/controllers/services_controller.rb
@@ -52,6 +52,7 @@ class ServicesController < ApplicationController
       end
     else
       @service.reload
+      @service.hydrate_linked_services!
       render :show
     end
   end

--- a/spec/controllers/services_controller_spec.rb
+++ b/spec/controllers/services_controller_spec.rb
@@ -204,11 +204,17 @@ describe ServicesController do
       before do
         valid_service.stub(:save).and_return(false)
         valid_service.stub(:reload).and_return(true)
+        valid_service.stub(:hydrate_linked_services!).and_return(true)
       end
 
       it 'reloads the service' do
         patch :update, app_id: 2, id: 3, service: attributes
         expect(valid_service).to have_received(:reload)
+      end
+
+      it 'rehydrates linked services' do
+        patch :update, app_id: 2, id: 3, service: attributes
+        expect(valid_service).to have_received(:hydrate_linked_services!)
       end
 
       it 're-renders the show page' do


### PR DESCRIPTION
Addition to previous bug -- need to rehydrate links after service reload.
