### PR TITLE
spacing on search titles should have larger gap between sections

### DIFF
--- a/app/assets/stylesheets/panamax/search.css.scss.erb
+++ b/app/assets/stylesheets/panamax/search.css.scss.erb
@@ -9,6 +9,10 @@ body#search_flow main:after {
   clear: both;
 }
 
+[class$='-results'] {
+  margin-bottom: 2.2em;
+}
+
 .template-details-dialog {
   position: absolute;
   top: 50px;
@@ -508,6 +512,8 @@ body#search_flow main:after {
 
 .search-title {
   display: none;
+  margin: 0;
+  padding-bottom: 0.4em;
 }
 
 .archetype {


### PR DESCRIPTION
[finishes: #76946038]

Thanks @rheinwein for the graphic.

![screen shot 2014-12-02 at 2 45 08 pm](https://cloud.githubusercontent.com/assets/923211/5270642/8555998a-7a32-11e4-9692-558b2c7a8ad7.png)
