### PR TITLE
set service restart flag to false when dragging into category

### DIFF
--- a/app/assets/javascripts/jquery.category_actions.js
+++ b/app/assets/javascripts/jquery.category_actions.js
@@ -84,6 +84,8 @@
           service.position = idx;
         }
 
+        service.restart_attribute = false;
+
         $.ajax({
           type: 'PUT',
           headers: {

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -58,6 +58,10 @@ class Service < BaseResource
     self.sub_state == 'running'
   end
 
+  def restart_attribute=(attribute)
+    self.restart = attribute
+  end
+
   def environment_attributes=(attributes)
     self.environment = attributes.each_with_object([]) do |(_, env), memo|
       memo << Environment.new(env.except('id')) unless env['_deleted'].to_s == '1'

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -220,6 +220,13 @@ describe Service do
 
   end
 
+  describe '#restart_attribute=' do
+    it 'assigns restart when present' do
+      subject.restart_attribute = 'true'
+      expect(subject.restart).to eq 'true'
+    end
+  end
+
   describe '#links_attributes=' do
     let(:attributes) do
       {


### PR DESCRIPTION
using a restart attribute on the service to tell the api if the service update should initiate an application restart