### PR TITLE
uber hack to ignore disk_map

### DIFF
--- a/app/models/machine_info.rb
+++ b/app/models/machine_info.rb
@@ -1,11 +1,30 @@
 require 'active_resource'
 
+#########
+## DiskMap only internally used to rewrite invalid key
+## ie the 8:0 key in the example below
+## 'disk_map' : {
+#    '8:0': {
+#    }
+#  }
+#########
+class DiskMap < BaseResource
+  include ActiveResource::Singleton
+
+  def find_or_create_resource_for(name)
+    name = name.to_s.gsub(':', '_').camelcase.to_sym
+    super("z_#{name}")
+  end
+end
+
 class MachineInfo < BaseResource
   include ActiveResource::Singleton
 
   self.site = "#{ENV['CADVISOR_PORT']}"
 
+  has_one :disk_map
+
   def self.singleton_path(_prefix_options={}, _query_options=nil)
-    '/api/v1.0/machine'
+    '/api/v1.2/machine'
   end
 end

--- a/spec/models/machine_info_spec.rb
+++ b/spec/models/machine_info_spec.rb
@@ -5,8 +5,8 @@ describe MachineInfo do
   it_behaves_like 'an active resource model'
 
   describe '.singleton_path' do
-    it 'returns /api/v1.0/machine' do
-      expect(MachineInfo.singleton_path).to eq '/api/v1.0/machine'
+    it 'returns /api/v1.2/machine' do
+      expect(MachineInfo.singleton_path).to eq '/api/v1.2/machine'
     end
   end
 end


### PR DESCRIPTION
uses a workaround to alter the naming of the disk_map nested element (ie 8:0 to a name which ruby can constantize).