### PR TITLE
Bugfix: broken save as template link

### DIFF
--- a/app/assets/javascripts/init.js
+++ b/app/assets/javascripts/init.js
@@ -33,6 +33,8 @@
 
     $('#manage_flow section.deployment-details').composeExportDialog();
 
+    $('.no-event-propagation').on('click', function (e) { e.stopPropagation(); });
+
     $('.category-panel').categoryActions();
 
     $('main').noticeActions();

--- a/app/views/apps/_application_button_menu.html.haml
+++ b/app/views/apps/_application_button_menu.html.haml
@@ -3,7 +3,7 @@
     .settings-container{ data: { toggle: { class: 'expanded'} } }
       %ul.settings-menu
         %li
-          = link_to 'Save as PMX Template', new_template_path(app_id: app.id), class: 'link template', title: 'save template'
+          = link_to 'Save as PMX Template', new_template_path(app_id: app.id), class: 'link template no-event-propagation', title: 'save template'
         %li
           = link_to 'Save As Compose YAML', '#', title: 'export', class: 'link export', data: { composePath: compose_yml_app_path(app.id) }
         %li


### PR DESCRIPTION
The change adds a special jquery selector and function to stop event propagation.  Using it on the app settings menu link to save app as template fixes the bug, allowing the browser to load the save as template view.
