### PR TITLE
Adding imagelayers link to search results

### DIFF
--- a/app/assets/stylesheets/panamax/images.css.scss
+++ b/app/assets/stylesheets/panamax/images.css.scss
@@ -72,7 +72,7 @@ ul.images li {
   padding-bottom: 22px;
   padding-top: 22px;
 
-  .image-layers-link {
+  .imagelayers-link {
     background: image-url('icon_image_layers.svg') -10px -17px;
     background-size: 40px 40px;
     float: left;

--- a/app/assets/stylesheets/panamax/search.css.scss.erb
+++ b/app/assets/stylesheets/panamax/search.css.scss.erb
@@ -203,6 +203,18 @@ body#search_flow main:after {
       font-size: 0.8em;
       line-height: 1.2;
     }
+
+    .imagelayers {
+      height: 40px;
+      width: 40px;
+      text-indent: -9999px;
+      color: transparent;
+      background: image-url('icon_image_layers.svg') -10px -17px no-repeat;
+      background-size: 40px 40px;
+      &:hover {
+        background-position: -10px 3px;
+      }
+    }
   }
 
   .actions {

--- a/app/models/base_image.rb
+++ b/app/models/base_image.rb
@@ -39,6 +39,15 @@ class BaseImage < BaseResource
     end
   end
 
+  def imagelayers_url
+    if remote?
+      "#{IMAGELAYERS_BASE_URL}?images=#{source}"
+    else
+      image_name = self.tags.first.split(':').first
+      "#{IMAGELAYERS_BASE_URL}?images=#{image_name}"
+    end
+  end
+
   def short_description
     truncate(description, length: 165, escape: false, separator: ' ')
   end
@@ -49,6 +58,7 @@ class BaseImage < BaseResource
         'status_label' => status_label,
         'short_description' => short_description,
         'docker_index_url' => docker_index_url,
+        'imagelayers_url' => imagelayers_url,
         'badge_class' => badge_class
       )
   end

--- a/app/models/base_resource.rb
+++ b/app/models/base_resource.rb
@@ -3,6 +3,7 @@ require 'active_resource'
 class BaseResource < ActiveResource::Base
 
   DOCKER_INDEX_BASE_URL = 'https://registry.hub.docker.com/'
+  IMAGELAYERS_BASE_URL = 'https://imagelayers.io/'
 
   self.site = PanamaxApi::URL
 

--- a/app/models/local_image.rb
+++ b/app/models/local_image.rb
@@ -1,13 +1,8 @@
 class LocalImage < BaseImage
   PANAMAX_IMAGE_NAMES = ['centurylink/panamax-ui:latest', 'centurylink/panamax-api:latest']
-  IMAGE_LAYERS_BASE_URL = 'https://ImageLayers.io'
 
   def panamax_image?
     PANAMAX_IMAGE_NAMES.include?(name)
-  end
-
-  def image_layers_url
-    IMAGE_LAYERS_BASE_URL + "?images=#{name}"
   end
 
   def local?

--- a/app/presenters/image_presenter.rb
+++ b/app/presenters/image_presenter.rb
@@ -6,7 +6,7 @@ class ImagePresenter
   end
 
   delegate :description, :status_label, :badge_class, :short_description,
-           :star_count, :docker_index_url, :registry_id,
+           :star_count, :docker_index_url, :imagelayers_url, :registry_id,
            to: :@image
 
   def title

--- a/app/presenters/json_image_presenter.rb
+++ b/app/presenters/json_image_presenter.rb
@@ -27,6 +27,10 @@ class JsonImagePresenter
     '{{docker_index_url}}'
   end
 
+  def imagelayers_url
+    '{{imagelayers_url}}'
+  end
+
   def badge_class
     '{{badge_class}}'
   end

--- a/app/views/images/index.html.haml
+++ b/app/views/images/index.html.haml
@@ -18,8 +18,8 @@
       %ul.images
         - @images.each do |image|
           %li
-            - il_message = "Inspect #{image.name} with ImageLayers.io"
-            = link_to il_message, image.image_layers_url, { class: 'image-layers-link', title: il_message, target: '_blank' }
+            - il_message = "Inspect #{image.name} with imagelayers.io"
+            = link_to il_message, image.imagelayers_url, { class: 'imagelayers-link', title: il_message, target: '_blank' }
             %h3= image.name
             %h6= image.tags[1..-1].try(:join, ', ')
             %dl

--- a/app/views/search/_image_row.html.haml
+++ b/app/views/search/_image_row.html.haml
@@ -5,7 +5,8 @@
   .basic-info
     %h3
       - if remote
-        = link_to presenter.title, presenter.docker_index_url, target: '_blank', title: 'View details on the Docker Hub'
+        = link_to presenter.title, presenter.docker_index_url, target: '_blank', title: 'View details on the Docker Hub', class: 'docker-hub'
+        = link_to presenter.title, presenter.imagelayers_url, target: '_blank', title: 'Inspect this image on imagelayers.io', class: 'imagelayers'
       - else
         = presenter.title
     %p= presenter.short_description

--- a/app/views/search/_modal_image_row.html.haml
+++ b/app/views/search/_modal_image_row.html.haml
@@ -4,7 +4,8 @@
   .basic-info
     %h3
       - if remote
-        = link_to presenter.title, presenter.docker_index_url, target: '_blank', title: 'View details on the Docker Hub'
+        = link_to presenter.title, presenter.docker_index_url, target: '_blank', title: 'View details on the Docker Hub', class: 'docker-hub'
+        = link_to presenter.title, presenter.imagelayers_url, target: '_blank', title: 'Inspect this image on imagelayers.io', class: 'imagelayers'
       - else
         = presenter.title
     %p= presenter.short_description

--- a/spec/features/manage_images_spec.rb
+++ b/spec/features/manage_images_spec.rb
@@ -11,7 +11,7 @@ describe 'managing images' do
     it 'can visit the image layers page for an image' do
       visit '/images'
 
-      expect(page).to have_link 'Inspect socialize_api:latest with ImageLayers.io', href: 'https://ImageLayers.io?images=socialize_api:latest'
+      expect(page).to have_link 'Inspect socialize_api:latest with imagelayers.io', href: 'https://imagelayers.io/?images=socialize_api'
     end
   end
 end

--- a/spec/features/search_spec.rb
+++ b/spec/features/search_spec.rb
@@ -20,7 +20,8 @@ describe 'searching for templates and images' do
       expect(page).to have_title 'Panamax > Search Results'
 
       # remote image result
-      expect(page.find_link('tutum/wordpress')['href']).to eq "#{DOCKER_INDEX_BASE_URL}u/tutum/wordpress"
+      expect(page.find_link('Docker Hub')['href']).to eq "#{DOCKER_INDEX_BASE_URL}u/tutum/wordpress"
+      expect(page.find_link('imagelayers.io')['href']).to eq "#{IMAGELAYERS_URL}?images=tutum/wordpress"
       expect(page).to have_content 'Wordpress Docker image - listens in port 80.'
       expect(page).to have_css '.star-count', text: '7'
 

--- a/spec/models/local_image_spec.rb
+++ b/spec/models/local_image_spec.rb
@@ -52,9 +52,9 @@ describe LocalImage do
     end
   end
 
-  describe '#image_layers_url' do
-    it 'concatenates the image layers URL with the image name' do
-      expect(subject.image_layers_url).to eq 'https://ImageLayers.io?images=blah/not-panamax'
+  describe '#imagelayers_url' do
+    it 'concatenates the imagelayers URL with the image name' do
+      expect(subject.imagelayers_url).to eq "#{IMAGELAYERS_URL}?images=blah/not-panamax"
     end
   end
 
@@ -124,7 +124,8 @@ describe LocalImage do
         'short_description' => 'this thing goes boom shaka laka',
         'status_label' => 'Local',
         'badge_class' => 'local',
-        'docker_index_url' => nil
+        'docker_index_url' => nil,
+        'imagelayers_url' => "#{IMAGELAYERS_URL}?images=blah/not-panamax"
       )
       expect(subject.as_json).to eq expected
     end

--- a/spec/models/remote_image_spec.rb
+++ b/spec/models/remote_image_spec.rb
@@ -59,7 +59,8 @@ describe RemoteImage do
         'short_description' => 'this thing goes boom shaka laka',
         'status_label' => 'Repository',
         'badge_class' => 'repository',
-        'docker_index_url' => "#{DOCKER_INDEX_BASE_URL}u/boom/shaka"
+        'docker_index_url' => "#{DOCKER_INDEX_BASE_URL}u/boom/shaka",
+        'imagelayers_url' => "#{IMAGELAYERS_URL}?images=boom/shaka"
       )
       expect(subject.as_json).to eq expected
     end

--- a/spec/presenters/image_presenter_spec.rb
+++ b/spec/presenters/image_presenter_spec.rb
@@ -12,7 +12,8 @@ describe ImagePresenter do
       status_label: 'Local',
       badge_class: 'local',
       star_count: 123,
-      docker_index_url: 'index.docker/boom/shaka'
+      docker_index_url: "#{DOCKER_INDEX_BASE_URL}boom/shaka",
+      imagelayers_url: "#{IMAGELAYERS_URL}?images=boom/shaka"
     )
   end
 
@@ -58,7 +59,13 @@ describe ImagePresenter do
 
   describe '#docker_index_url' do
     it 'exposes the docker index url' do
-      expect(subject.docker_index_url).to eq 'index.docker/boom/shaka'
+      expect(subject.docker_index_url).to eq "#{DOCKER_INDEX_BASE_URL}boom/shaka"
+    end
+  end
+
+  describe '#imagelayers_url' do
+    it 'exposes the imagelayers url' do
+      expect(subject.imagelayers_url).to eq "#{IMAGELAYERS_URL}?images=boom/shaka"
     end
   end
 

--- a/spec/presenters/json_image_presenter_spec.rb
+++ b/spec/presenters/json_image_presenter_spec.rb
@@ -43,6 +43,12 @@ describe JsonImagePresenter do
     end
   end
 
+  describe '#imagelayers_url' do
+    it 'exposes the handlebar template tag for imagelayers url' do
+      expect(subject.imagelayers_url).to eq '{{imagelayers_url}}'
+    end
+  end
+
   describe '#badge_class' do
     it 'exposes handlebar template for badge_class' do
       expect(subject.badge_class).to eq '{{badge_class}}'

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,6 +23,7 @@ if ENV['CIRCLE_ARTIFACTS'] || ENV['COVERAGE'].present?
 end
 
 DOCKER_INDEX_BASE_URL = 'https://registry.hub.docker.com/'
+IMAGELAYERS_URL = 'https://imagelayers.io/'
 
 # Requires supporting ruby files with custom matchers and macros, etc,
 # in spec/support/ and its subdirectories.


### PR DESCRIPTION
Adding imagelayers icon next to remote images in both the main search results as well as the modal. Behavior is the same as on the image list page.
![image](https://cloud.githubusercontent.com/assets/775634/8235032/39ab615e-15a5-11e5-996e-aa33d6f93491.png)
