### PR TITLE
cleaning up modal dialog fixtures during jasmine test runs

### DIFF
--- a/spec/javascripts/spec_helper.js
+++ b/spec/javascripts/spec_helper.js
@@ -34,3 +34,7 @@ jQuery.PMX.ogInit = jQuery.PMX.init;
 jQuery.PMX.init = function() {};
 
 jQuery.fn.errorInterceptor = function() { };
+
+afterEach(function () {
+  $('.ui-dialog').remove();
+});


### PR DESCRIPTION
Adds a global afterEach to the jasmine spec_helper.js to clean up leftover DOM elements added to the document body during modal dialog creation.  These elements were leaking into other test fixtures and causing failures.